### PR TITLE
Add machine-token wire format

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -13,6 +13,10 @@ import {
   MAX_PRESIGNED_URL_ISSUANCES_PER_ACCOUNT_PER_MINUTE,
   MAX_RETAINED_AND_STAGED_BYTES_PER_ACCOUNT,
   MAX_UPLOAD_CONCURRENCY_PER_MACHINE,
+  MACHINE_TOKEN_PREFIX,
+  MACHINE_TOKEN_VERSION,
+  generateMachineToken,
+  parseMachineToken,
 } from "./index.js";
 
 describe("@zudo-ez-host/core", () => {
@@ -43,6 +47,15 @@ describe("@zudo-ez-host/core", () => {
       MAX_PREPARES_PER_ACCOUNT_PER_MINUTE: 5,
       MAX_COMMITS_PER_PROJECT_PER_MINUTE: 10,
       MAX_PRESIGNED_URL_ISSUANCES_PER_ACCOUNT_PER_MINUTE: 1_000,
+    });
+  });
+
+  it("exports the machine-token wire helpers from the core barrel", () => {
+    const parsed = parseMachineToken(generateMachineToken());
+
+    expect(parsed).toEqual({
+      ok: true,
+      value: { prefix: MACHINE_TOKEN_PREFIX, version: MACHINE_TOKEN_VERSION },
     });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,3 +53,4 @@ export type {
   ValidatedManifestLookup,
 } from "./manifest/index.js";
 export * from "./serving/index.js";
+export * from "./machine-token/index.js";

--- a/packages/core/src/machine-token/index.test.ts
+++ b/packages/core/src/machine-token/index.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MACHINE_TOKEN_LENGTH,
+  MACHINE_TOKEN_PREFIX,
+  MACHINE_TOKEN_RANDOM_LENGTH,
+  MACHINE_TOKEN_VERSION,
+  MACHINE_TOKEN_WIRE_PREFIX,
+  generateMachineToken,
+  hashMachineToken,
+  parseMachineToken,
+} from "./index.js";
+
+const VALID_TOKEN = `${MACHINE_TOKEN_WIRE_PREFIX}${"A".repeat(MACHINE_TOKEN_RANDOM_LENGTH)}`;
+
+function rejectionReason(input: unknown): string {
+  const result = parseMachineToken(input);
+  if (result.ok) {
+    throw new Error("Expected machine token parsing to fail");
+  }
+  return result.reason;
+}
+
+describe("machine-token wire format", () => {
+  it("generates 32 random bytes as an exact V1 token and parses its metadata", () => {
+    const token = generateMachineToken();
+
+    expect(token).toHaveLength(MACHINE_TOKEN_LENGTH);
+    expect(token.startsWith(MACHINE_TOKEN_WIRE_PREFIX)).toBe(true);
+    expect(parseMachineToken(token)).toEqual({
+      ok: true,
+      value: { prefix: MACHINE_TOKEN_PREFIX, version: MACHINE_TOKEN_VERSION },
+    });
+  });
+
+  it("rejects a tampered token whose random portion leaves the wire alphabet", () => {
+    const token = generateMachineToken();
+    const tampered = `${token.slice(0, -1)}!`;
+
+    expect(rejectionReason(tampered)).toBe("invalid_alphabet");
+  });
+
+  it("rejects a wrong prefix", () => {
+    const wrongPrefix = `foo_machine_v1_${"A".repeat(MACHINE_TOKEN_RANDOM_LENGTH)}`;
+
+    expect(rejectionReason(wrongPrefix)).toBe("invalid_prefix");
+  });
+
+  it.each([
+    `${MACHINE_TOKEN_WIRE_PREFIX}${"A".repeat(MACHINE_TOKEN_RANDOM_LENGTH - 1)}`,
+    `${MACHINE_TOKEN_WIRE_PREFIX}${"A".repeat(MACHINE_TOKEN_RANDOM_LENGTH + 1)}`,
+  ])("rejects a wrong-length token: %s", (token) => {
+    expect(rejectionReason(token)).toBe("invalid_length");
+  });
+
+  it("rejects characters outside the unpadded base64url alphabet", () => {
+    const invalidAlphabet = `${MACHINE_TOKEN_WIRE_PREFIX}${"A".repeat(42)}!`;
+
+    expect(rejectionReason(invalidAlphabet)).toBe("invalid_alphabet");
+  });
+
+  it("rejects a non-canonical final base64url character", () => {
+    const nonCanonical = `${MACHINE_TOKEN_WIRE_PREFIX}${"A".repeat(42)}B`;
+
+    expect(rejectionReason(nonCanonical)).toBe("non_canonical_encoding");
+  });
+
+  it("rejects non-string input", () => {
+    expect(rejectionReason(undefined)).toBe("not_string");
+  });
+});
+
+describe("hashMachineToken", () => {
+  it("matches an independently computed SHA-256 known-answer vector", async () => {
+    // Independent reference: printf %s '...' | shasum -a 256
+    expect(await hashMachineToken(VALID_TOKEN)).toBe(
+      "fd43e091b6ebcf38b883b124bc0b1ef321c826cfd87af2fdbfee31a9996422f6",
+    );
+  });
+});

--- a/packages/core/src/machine-token/index.ts
+++ b/packages/core/src/machine-token/index.ts
@@ -1,0 +1,133 @@
+import type { ValidationResult } from "../contracts.js";
+
+/** The non-secret family prefix shared by all machine credentials. */
+export const MACHINE_TOKEN_PREFIX = "zeh_machine_" as const;
+
+/** The machine-credential wire-format version implemented by this package. */
+export const MACHINE_TOKEN_VERSION = 1 as const;
+
+/** The exact prefix written before a machine credential's random bytes. */
+export const MACHINE_TOKEN_WIRE_PREFIX =
+  `${MACHINE_TOKEN_PREFIX}v${MACHINE_TOKEN_VERSION}_` as const;
+
+/** The number of random bytes in a V1 machine credential. */
+export const MACHINE_TOKEN_RANDOM_BYTES = 32 as const;
+
+/** The unpadded base64url length of MACHINE_TOKEN_RANDOM_BYTES. */
+export const MACHINE_TOKEN_RANDOM_LENGTH = 43 as const;
+
+/** The complete length of a V1 machine credential. */
+export const MACHINE_TOKEN_LENGTH = MACHINE_TOKEN_WIRE_PREFIX.length + MACHINE_TOKEN_RANDOM_LENGTH;
+
+const BASE64URL_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+const textEncoder = new TextEncoder();
+
+/** Stable reasons returned when a machine credential has an invalid shape. */
+export type MachineTokenRejectionReason =
+  | "not_string"
+  | "invalid_prefix"
+  | "invalid_length"
+  | "invalid_alphabet"
+  | "non_canonical_encoding";
+
+/** The non-secret data extracted from a validated machine credential. */
+export interface MachineTokenMetadata {
+  readonly prefix: typeof MACHINE_TOKEN_PREFIX;
+  readonly version: typeof MACHINE_TOKEN_VERSION;
+}
+
+export type MachineTokenParseResult = ValidationResult<
+  MachineTokenMetadata,
+  MachineTokenRejectionReason
+>;
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let encoded = "";
+
+  for (let index = 0; index < bytes.length; index += 3) {
+    const first = bytes[index] as number;
+    const second = bytes[index + 1];
+    const third = bytes[index + 2];
+
+    encoded += BASE64URL_ALPHABET[first >>> 2];
+    encoded +=
+      BASE64URL_ALPHABET[((first & 0x03) << 4) | (second === undefined ? 0 : second >>> 4)];
+
+    if (second === undefined) {
+      break;
+    }
+
+    encoded += BASE64URL_ALPHABET[((second & 0x0f) << 2) | (third === undefined ? 0 : third >>> 6)];
+
+    if (third === undefined) {
+      break;
+    }
+
+    encoded += BASE64URL_ALPHABET[third & 0x3f];
+  }
+
+  return encoded;
+}
+
+function base64UrlValue(character: string): number {
+  return BASE64URL_ALPHABET.indexOf(character);
+}
+
+/**
+ * Generate a V1 machine credential using 256 bits of cryptographically secure
+ * randomness. The returned value is the only raw credential representation.
+ */
+export function generateMachineToken(): string {
+  const randomBytes = new Uint8Array(MACHINE_TOKEN_RANDOM_BYTES);
+  globalThis.crypto.getRandomValues(randomBytes);
+  return `${MACHINE_TOKEN_WIRE_PREFIX}${encodeBase64Url(randomBytes)}`;
+}
+
+/**
+ * Validate a machine credential's exact V1 wire shape and extract its
+ * non-secret family prefix and version.
+ *
+ * Shape validation deliberately does not authenticate a token. A different
+ * valid random suffix is still syntactically well-formed; the server's hash
+ * lookup determines whether it was minted and has not been revoked.
+ */
+export function parseMachineToken(input: unknown): MachineTokenParseResult {
+  if (typeof input !== "string") {
+    return { ok: false, reason: "not_string" };
+  }
+
+  if (!input.startsWith(MACHINE_TOKEN_WIRE_PREFIX)) {
+    return { ok: false, reason: "invalid_prefix" };
+  }
+
+  if (input.length !== MACHINE_TOKEN_LENGTH) {
+    return { ok: false, reason: "invalid_length" };
+  }
+
+  const randomPart = input.slice(MACHINE_TOKEN_WIRE_PREFIX.length);
+  if (!BASE64URL_PATTERN.test(randomPart)) {
+    return { ok: false, reason: "invalid_alphabet" };
+  }
+
+  // 32 bytes produce 43 base64url characters. The final character contains
+  // four data bits and two required zero pad bits in a canonical encoding.
+  const finalValue = base64UrlValue(randomPart.at(-1) as string);
+  if ((finalValue & 0x03) !== 0) {
+    return { ok: false, reason: "non_canonical_encoding" };
+  }
+
+  return {
+    ok: true,
+    value: {
+      prefix: MACHINE_TOKEN_PREFIX,
+      version: MACHINE_TOKEN_VERSION,
+    },
+  };
+}
+
+/** Return the lowercase hexadecimal SHA-256 digest of the complete token. */
+export async function hashMachineToken(token: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", textEncoder.encode(token));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}


### PR DESCRIPTION
Parent: #41

Implements #44.

## Summary

- add the versioned `zeh_machine_v1_` credential wire format
- validate, parse, generate, and SHA-256 hash full machine tokens with Web APIs
- export the contract through `@zudo-ez-host/core` with boundary tests

## Test plan

- core Vitest suite
- typecheck, lint, and format check
- worker foreground review — no findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-ez-host/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790425506&installation_model_id=20910&pr_number=65&repository=zudolab%2Fzudo-ez-host&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-ez-host%2Fpull%2F65&signature=d686004990687d8b83cfad9fb9dd4303c03f6313ef7657a091006ff8a60d1682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->