### PR TITLE
Enforce session and origin boundaries

### DIFF
--- a/workers/control/src/account/router.ts
+++ b/workers/control/src/account/router.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+
+/** Wave-4 mount point; unmatched account routes have one stable empty response. */
+export const accountRouter = new Hono<{ Bindings: ControlEnv }>().all("*", (context) =>
+  context.json({ error: "route_not_implemented" }, 404, { "Cache-Control": "no-store" }),
+);

--- a/workers/control/src/app.ts
+++ b/workers/control/src/app.ts
@@ -1,10 +1,13 @@
 import { Hono } from "hono";
 
+import { accountRouter } from "./account/router.js";
 import {
   MACHINE_AUTH_PUBLISH_PATH,
   machineAuthMiddleware,
-  type MachineAuthEnv,
+  type MachineAuthVariables,
 } from "./auth/machine-auth.js";
+import { exactControlCorsMiddleware, requireTrustedOriginMiddleware } from "./auth/origin.js";
+import { sessionAuthMiddleware, type SessionAuthVariables } from "./auth/session-auth.js";
 import {
   hasSameOrigin,
   LoginFormError,
@@ -12,6 +15,8 @@ import {
   readLoginForm,
   safeReturnTo,
 } from "./auth/login-page.js";
+import { desktopRouter } from "./desktop/router.js";
+import { machinesRouter } from "./machines/router.js";
 import { projectsRouter } from "./projects/index.js";
 import {
   createPublicationContractsRouter,
@@ -29,13 +34,28 @@ export interface ControlAppOptions {
   readonly contracts?: PublicationContractsRouterOptions;
 }
 
+interface ControlAppEnv {
+  readonly Bindings: ControlEnv;
+  readonly Variables: MachineAuthVariables & SessionAuthVariables;
+}
+
+function mountSessionBoundary(app: Hono<ControlAppEnv>, path: string) {
+  for (const pattern of [path, `${path}/*`]) {
+    app.use(pattern, exactControlCorsMiddleware);
+    app.use(pattern, requireTrustedOriginMiddleware);
+    app.use(pattern, sessionAuthMiddleware);
+  }
+}
+
 /** Build the control app with deployment-owned publication dependencies. */
-export function createControlApp(options: ControlAppOptions = {}): Hono<MachineAuthEnv> {
-  const app = new Hono<MachineAuthEnv>();
+export function createControlApp(options: ControlAppOptions = {}): Hono<ControlAppEnv> {
+  const app = new Hono<ControlAppEnv>();
   const publicationPrepareRouter = createPublicationPrepareRouter(options.prepare);
   const publicationContractsRouter = createPublicationContractsRouter(options.contracts);
 
   app.route("/", healthRouter);
+  app.use("/login", exactControlCorsMiddleware);
+  app.use("/login", requireTrustedOriginMiddleware);
   app.get("/login", (context) => loginPageResponse(safeReturnTo(context.req.query("returnTo"))));
   app.post("/login", async (context) => {
     if (!hasSameOrigin(context.req.raw)) {
@@ -86,6 +106,7 @@ export function createControlApp(options: ControlAppOptions = {}): Hono<MachineA
       redirect.headers.append("set-cookie", cookie);
     return redirect;
   });
+  app.use("/api/auth/*", exactControlCorsMiddleware);
   app.all("/api/auth/*", async (context) => {
     const { createAuth } = await import("./auth/better-auth.js");
     const url = new URL(context.req.url);
@@ -93,9 +114,13 @@ export function createControlApp(options: ControlAppOptions = {}): Hono<MachineA
       context.req.method === "POST" && url.pathname === "/api/auth/sign-up/email";
     return createAuth(context.env, { enableInvitedEmailSignUp }).handler(context.req.raw);
   });
-  app.use("/projects", machineAuthMiddleware);
-  app.use("/projects/*", machineAuthMiddleware);
-  app.route("/projects", projectsRouter);
+  mountSessionBoundary(app, "/api/account");
+  mountSessionBoundary(app, "/api/machines");
+  mountSessionBoundary(app, "/desktop/authorize");
+  app.route("/api/account", accountRouter);
+  app.route("/api/machines", machinesRouter);
+  app.route("/desktop", desktopRouter);
+  app.route("/api/projects", projectsRouter);
   app.use(MACHINE_AUTH_PUBLISH_PATH, machineAuthMiddleware);
   app.route("/api/projects/:projectId/publish", publicationPrepareRouter);
   app.route("/api/projects/:projectId/publish", publicationContractsRouter);

--- a/workers/control/src/auth/index.ts
+++ b/workers/control/src/auth/index.ts
@@ -2,3 +2,5 @@ export * from "./machine-auth.js";
 export * from "./better-auth.js";
 export * from "./invite.js";
 export * from "./login-page.js";
+export * from "./origin.js";
+export * from "./session-auth.js";

--- a/workers/control/src/auth/machine-auth.test.ts
+++ b/workers/control/src/auth/machine-auth.test.ts
@@ -114,7 +114,25 @@ describe("machine publish authentication", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       userId: user.id,
-      canonicalHandle: user.canonicalHandle,
+      machineId: machine.id,
+    });
+  });
+
+  it("does not require the separate canonical-handle claim", async () => {
+    const { token, user, machine } = await seedAuthenticatedMachine({
+      machineId: "mch_unclaimed",
+      userId: "usr_unclaimed",
+      canonicalHandle: "temporary",
+    });
+    await env.DB.prepare("UPDATE user SET canonical_handle = NULL WHERE id = ?")
+      .bind(user.id)
+      .run();
+
+    const response = await request(token);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      userId: user.id,
       machineId: machine.id,
     });
   });
@@ -197,7 +215,6 @@ describe("machine publish authentication", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       userId: ownerA.user.id,
-      canonicalHandle: ownerA.user.canonicalHandle,
       machineId: ownerA.machine.id,
     });
   });

--- a/workers/control/src/auth/machine-auth.ts
+++ b/workers/control/src/auth/machine-auth.ts
@@ -9,7 +9,7 @@ import type { MiddlewareHandler } from "hono";
 import { createMiddleware } from "hono/factory";
 
 import { createControlDatabase } from "../db/database.js";
-import { getMachineByCredentialHash, getUserById } from "../db/queries.js";
+import { getMachineByCredentialHash } from "../db/queries.js";
 
 /** The Hono context variable containing the authenticated machine owner. */
 export const MACHINE_AUTH_CONTEXT_KEY = "machineAuth" as const;
@@ -18,16 +18,15 @@ export const MACHINE_AUTH_CONTEXT_KEY = "machineAuth" as const;
 export const MACHINE_AUTH_SCOPE = "project_publish" as const;
 
 /**
- * Publish endpoints are the only routes that may use machine credentials.
- * Project registration, account, and credential-management routes must use a
- * different authentication boundary when they are added.
+ * Machine credentials are limited to project and publish operations. Account
+ * and credential-management routes remain browser-session-only. See the
+ * identity ADR and `doc/src/content/docs/sync/mac-client.mdx`.
  */
 export const MACHINE_AUTH_PUBLISH_PATH = "/api/projects/:projectId/publish/*" as const;
 
 /** The owner identity downstream project and publication code may consume. */
 export interface MachineAuthContext {
   readonly userId: string;
-  readonly canonicalHandle: string;
   readonly machineId: string;
 }
 
@@ -111,7 +110,7 @@ function parseAuthorization(request: Request): AuthorizationResult {
  * The token is parsed and hashed in request memory only. The database stores
  * and receives the digest, never the bearer value itself. The returned context
  * intentionally contains no request-owned project, handle, or credential
- * data; all identity fields come from the machine and user rows.
+ * data; all identity fields come from the machine row.
  */
 export async function authenticateMachineToken(
   token: unknown,
@@ -158,28 +157,24 @@ export async function authenticateMachineToken(
     return errorResult("expired_credential");
   }
 
-  const user = await getUserById(database, machine.userId);
-  if (user === undefined) {
-    // The schema's foreign key should make this unreachable. Treat any
-    // inconsistent row as unknown rather than exposing account state.
-    return errorResult("unknown_credential");
-  }
-
-  // Better Auth creates users before the separate handle-claim flow. Until
-  // publish auth stops carrying handles, an unclaimed account cannot form the
-  // existing publish identity and uses the same non-enumerating failure.
-  if (user.canonicalHandle === null) {
-    return errorResult("unknown_credential");
-  }
-
   return {
     ok: true,
     value: {
-      userId: user.id,
-      canonicalHandle: user.canonicalHandle,
+      userId: machine.userId,
       machineId: machine.id,
     },
   };
+}
+
+/** Authenticate the complete HTTP bearer boundary without falling back to cookies. */
+export async function authenticateMachineRequest(
+  request: Request,
+  binding: D1Database,
+  now = Date.now(),
+): Promise<MachineAuthResult> {
+  const authorization = parseAuthorization(request);
+  if (!authorization.ok) return errorResult(authorization.reason);
+  return authenticateMachineToken(authorization.token, binding, now);
 }
 
 function unauthorizedResponse(
@@ -199,15 +194,7 @@ export function createMachineAuthMiddleware(
   const now = options.now ?? (() => Date.now());
 
   return createMiddleware<MachineAuthEnv>(async (context, next) => {
-    const authorization = parseAuthorization(context.req.raw);
-    if (!authorization.ok) {
-      return unauthorizedResponse(context, {
-        error: "machine_authentication_failed",
-        reason: authorization.reason,
-      });
-    }
-
-    const result = await authenticateMachineToken(authorization.token, context.env.DB, now());
+    const result = await authenticateMachineRequest(context.req.raw, context.env.DB, now());
     if (!result.ok) {
       return unauthorizedResponse(context, result.error);
     }

--- a/workers/control/src/auth/machine-auth.ts
+++ b/workers/control/src/auth/machine-auth.ts
@@ -9,7 +9,7 @@ import type { MiddlewareHandler } from "hono";
 import { createMiddleware } from "hono/factory";
 
 import { createControlDatabase } from "../db/database.js";
-import { getMachineByCredentialHash } from "../db/queries.js";
+import { getMachineByCredentialHash, getUserById } from "../db/queries.js";
 
 /** The Hono context variable containing the authenticated machine owner. */
 export const MACHINE_AUTH_CONTEXT_KEY = "machineAuth" as const;
@@ -110,7 +110,7 @@ function parseAuthorization(request: Request): AuthorizationResult {
  * The token is parsed and hashed in request memory only. The database stores
  * and receives the digest, never the bearer value itself. The returned context
  * intentionally contains no request-owned project, handle, or credential
- * data; all identity fields come from the machine row.
+ * data; all identity fields come from the machine and user rows.
  */
 export async function authenticateMachineToken(
   token: unknown,
@@ -157,10 +157,17 @@ export async function authenticateMachineToken(
     return errorResult("expired_credential");
   }
 
+  const user = await getUserById(database, machine.userId);
+  if (user === undefined) {
+    // The foreign key should make this unreachable. Keep the auth boundary
+    // fail-closed if storage is nevertheless inconsistent.
+    return errorResult("unknown_credential");
+  }
+
   return {
     ok: true,
     value: {
-      userId: machine.userId,
+      userId: user.id,
       machineId: machine.id,
     },
   };

--- a/workers/control/src/auth/origin.test.ts
+++ b/workers/control/src/auth/origin.test.ts
@@ -106,14 +106,22 @@ describe("exact control origins", () => {
     }
   });
 
-  it("allows origin-less safe session GETs and keeps desktop token cookie-free", async () => {
+  it("mounts all skeletons with their intended session boundary", async () => {
     const authEnv = runtimeEnv();
     const cookie = await sessionCookie(authEnv);
     const app = createControlApp();
 
-    const safe = await app.request(`${BASE_URL}/api/machines`, { headers: { cookie } }, authEnv);
-    expect(safe.status).toBe(404);
-    await expect(safe.json()).resolves.toEqual({ error: "route_not_implemented" });
+    for (const path of ["/api/account", "/api/machines", "/desktop/authorize"]) {
+      const anonymous = await app.request(`${BASE_URL}${path}`, {}, authEnv);
+      expect(anonymous.status, path).toBe(401);
+      await expect(anonymous.json()).resolves.toEqual({
+        error: "session_authentication_required",
+      });
+
+      const safe = await app.request(`${BASE_URL}${path}`, { headers: { cookie } }, authEnv);
+      expect(safe.status, path).toBe(404);
+      await expect(safe.json()).resolves.toEqual({ error: "route_not_implemented" });
+    }
 
     const anonymousToken = await app.request(`${BASE_URL}/desktop/token`, {}, authEnv);
     const cookieToken = await app.request(
@@ -142,5 +150,17 @@ describe("exact control origins", () => {
       authEnv,
     );
     expect(unknown.headers.get("access-control-allow-origin")).toBeNull();
+
+    const rejectedMutation = await app.request(
+      `${BASE_URL}/api/auth/sign-in/email`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: "https://evil.test" },
+        body: JSON.stringify({ email: EMAIL, password: "irrelevant" }),
+      },
+      authEnv,
+    );
+    expect(rejectedMutation.status).toBe(403);
+    expect(rejectedMutation.headers.get("access-control-allow-origin")).toBeNull();
   });
 });

--- a/workers/control/src/auth/origin.test.ts
+++ b/workers/control/src/auth/origin.test.ts
@@ -1,0 +1,146 @@
+import { env } from "cloudflare:workers";
+import { reset } from "cloudflare:test";
+import { beforeEach, describe, expect, inject, it } from "vitest";
+
+import { createControlApp } from "../app.js";
+import { applyControlMigrations } from "../db/testing.js";
+import { createAuth, type AuthRuntimeEnv } from "./better-auth.js";
+import { hasExactTrustedOrigin, trustedControlOrigins } from "./origin.js";
+
+const BASE_URL = "https://control.test";
+const EMAIL = "origin@example.test";
+
+function runtimeEnv(): ControlEnv & AuthRuntimeEnv {
+  return {
+    DB: env.DB,
+    ARTIFACTS: env.ARTIFACTS,
+    PUBLICATION_RESOLVER: env.PUBLICATION_RESOLVER,
+    BETTER_AUTH_SECRET: `${crypto.randomUUID()}${crypto.randomUUID()}`,
+    BETTER_AUTH_BASE_URL: BASE_URL,
+    BETTER_AUTH_TRUSTED_ORIGINS: BASE_URL,
+    SIGNUP_ALLOWED_EMAILS: EMAIL,
+  };
+}
+
+async function sessionCookie(authEnv: AuthRuntimeEnv) {
+  const response = await createAuth(authEnv, { enableInvitedEmailSignUp: true }).handler(
+    new Request(`${BASE_URL}/api/auth/sign-up/email`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: BASE_URL },
+      body: JSON.stringify({
+        name: "Origin User",
+        email: EMAIL,
+        password: "correct horse battery staple",
+      }),
+    }),
+  );
+  const header = response.headers
+    .getSetCookie()
+    .find((value) => value.startsWith("__Host-zudo.session_token="));
+  if (!header) throw new Error("Expected a session cookie");
+  return header.split(";", 1)[0] ?? "";
+}
+
+beforeEach(async () => {
+  await reset();
+  await applyControlMigrations(env.DB, inject("controlMigrations"));
+});
+
+describe("exact control origins", () => {
+  it("accepts only canonical configured HTTP(S) origins", () => {
+    expect(trustedControlOrigins("https://control.test,http://localhost:3000")).toEqual([
+      "https://control.test",
+      "http://localhost:3000",
+    ]);
+    expect(
+      hasExactTrustedOrigin(new Request(BASE_URL, { headers: { origin: BASE_URL } }), BASE_URL),
+    ).toBe(true);
+    for (const origin of [
+      "null",
+      "https://evil.test",
+      "https://control.test.evil.test",
+      "https://control.test, https://evil.test",
+      "not an origin",
+      "https://site.public-content.test",
+    ]) {
+      expect(hasExactTrustedOrigin(new Request(BASE_URL, { headers: { origin } }), BASE_URL)).toBe(
+        false,
+      );
+    }
+    expect(hasExactTrustedOrigin(new Request(BASE_URL), BASE_URL)).toBe(false);
+  });
+
+  it("enforces the mutation matrix at the mounted request boundary", async () => {
+    const authEnv = runtimeEnv();
+    const cookie = await sessionCookie(authEnv);
+    const app = createControlApp();
+
+    const allowed = await app.request(
+      `${BASE_URL}/api/account/profile`,
+      { method: "POST", headers: { cookie, origin: BASE_URL } },
+      authEnv,
+    );
+    expect(allowed.status).toBe(404);
+    await expect(allowed.json()).resolves.toEqual({ error: "route_not_implemented" });
+
+    const rejectedOrigins: Array<string | undefined> = [
+      undefined,
+      "null",
+      "https://evil.test",
+      "https://control.test.evil.test",
+      "https://control.test, https://evil.test",
+      "not an origin",
+      "https://site.public-content.test",
+    ];
+    for (const origin of rejectedOrigins) {
+      const headers = new Headers({ cookie });
+      if (origin !== undefined) headers.set("origin", origin);
+      const response = await app.request(
+        `${BASE_URL}/api/account/profile`,
+        { method: "POST", headers },
+        authEnv,
+      );
+      expect(response.status, origin).toBe(403);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      await expect(response.json()).resolves.toEqual({ error: "invalid_origin" });
+    }
+  });
+
+  it("allows origin-less safe session GETs and keeps desktop token cookie-free", async () => {
+    const authEnv = runtimeEnv();
+    const cookie = await sessionCookie(authEnv);
+    const app = createControlApp();
+
+    const safe = await app.request(`${BASE_URL}/api/machines`, { headers: { cookie } }, authEnv);
+    expect(safe.status).toBe(404);
+    await expect(safe.json()).resolves.toEqual({ error: "route_not_implemented" });
+
+    const anonymousToken = await app.request(`${BASE_URL}/desktop/token`, {}, authEnv);
+    const cookieToken = await app.request(
+      `${BASE_URL}/desktop/token`,
+      { headers: { cookie } },
+      authEnv,
+    );
+    expect(cookieToken.status).toBe(anonymousToken.status);
+    await expect(cookieToken.json()).resolves.toEqual(await anonymousToken.json());
+  });
+
+  it("runs exact credentialed CORS before Better Auth", async () => {
+    const authEnv = runtimeEnv();
+    const app = createControlApp();
+    const trusted = await app.request(
+      `${BASE_URL}/api/auth/get-session`,
+      { method: "OPTIONS", headers: { origin: BASE_URL } },
+      authEnv,
+    );
+    expect(trusted.headers.get("access-control-allow-origin")).toBe(BASE_URL);
+    expect(trusted.headers.get("access-control-allow-credentials")).toBe("true");
+
+    const unknown = await app.request(
+      `${BASE_URL}/api/auth/get-session`,
+      { method: "OPTIONS", headers: { origin: "https://evil.test" } },
+      authEnv,
+    );
+    expect(unknown.headers.get("access-control-allow-origin")).toBeNull();
+  });
+});

--- a/workers/control/src/auth/origin.ts
+++ b/workers/control/src/auth/origin.ts
@@ -1,0 +1,82 @@
+import type { MiddlewareHandler } from "hono";
+import { cors } from "hono/cors";
+import { createMiddleware } from "hono/factory";
+
+import type { AuthRuntimeEnv } from "./better-auth.js";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+export interface OriginPolicyEnv {
+  readonly Bindings: AuthRuntimeEnv;
+}
+
+/** Parse the deployment allowlist as exact serialized HTTP(S) origins. */
+export function trustedControlOrigins(value: string | undefined): readonly string[] {
+  const origins = (value ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  if (origins.length === 0) {
+    throw new Error("BETTER_AUTH_TRUSTED_ORIGINS must contain at least one exact origin");
+  }
+
+  for (const origin of origins) {
+    let parsed: URL;
+    try {
+      parsed = new URL(origin);
+    } catch {
+      throw new Error("BETTER_AUTH_TRUSTED_ORIGINS contains a malformed origin");
+    }
+    if (
+      (parsed.protocol !== "https:" && parsed.protocol !== "http:") ||
+      parsed.origin !== origin ||
+      parsed.username !== "" ||
+      parsed.password !== "" ||
+      parsed.pathname !== "/" ||
+      parsed.search !== "" ||
+      parsed.hash !== ""
+    ) {
+      throw new Error("BETTER_AUTH_TRUSTED_ORIGINS must contain exact HTTP(S) origins");
+    }
+  }
+
+  return [...new Set(origins)];
+}
+
+/** True only for one present, canonical Origin value in the deployment allowlist. */
+export function hasExactTrustedOrigin(request: Request, configuredOrigins: string | undefined) {
+  const origin = request.headers.get("Origin");
+  if (origin === null || origin === "null" || origin.includes(",")) return false;
+  return trustedControlOrigins(configuredOrigins).includes(origin);
+}
+
+/** Credentialed CORS with an exact, deployment-owned origin allowlist. */
+export const exactControlCorsMiddleware: MiddlewareHandler<OriginPolicyEnv> = createMiddleware(
+  async (context, next) => {
+    const middleware = cors({
+      origin: [...trustedControlOrigins(context.env.BETTER_AUTH_TRUSTED_ORIGINS)],
+      credentials: true,
+      allowMethods: ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    });
+    return middleware(context, next);
+  },
+);
+
+/**
+ * Require an explicit trusted Origin for application cookie mutations.
+ *
+ * CORS must run before this middleware so a valid preflight can terminate
+ * without being mistaken for an application mutation.
+ */
+export const requireTrustedOriginMiddleware: MiddlewareHandler<OriginPolicyEnv> = createMiddleware(
+  async (context, next) => {
+    if (
+      !SAFE_METHODS.has(context.req.method) &&
+      !hasExactTrustedOrigin(context.req.raw, context.env.BETTER_AUTH_TRUSTED_ORIGINS)
+    ) {
+      return context.json({ error: "invalid_origin" }, 403, { "Cache-Control": "no-store" });
+    }
+    await next();
+  },
+);

--- a/workers/control/src/auth/session-auth.test.ts
+++ b/workers/control/src/auth/session-auth.test.ts
@@ -1,0 +1,86 @@
+import { env } from "cloudflare:workers";
+import { reset } from "cloudflare:test";
+import { Hono } from "hono";
+import { beforeEach, describe, expect, inject, it } from "vitest";
+
+import { applyControlMigrations } from "../db/testing.js";
+import { createAuth, type AuthRuntimeEnv } from "./better-auth.js";
+import {
+  SESSION_AUTH_CONTEXT_KEY,
+  sessionAuthMiddleware,
+  type SessionAuthEnv,
+} from "./session-auth.js";
+
+const BASE_URL = "https://control.test";
+const EMAIL = "session@example.test";
+
+function runtimeEnv(): AuthRuntimeEnv {
+  return {
+    DB: env.DB,
+    BETTER_AUTH_SECRET: `${crypto.randomUUID()}${crypto.randomUUID()}`,
+    BETTER_AUTH_BASE_URL: BASE_URL,
+    BETTER_AUTH_TRUSTED_ORIGINS: BASE_URL,
+    SIGNUP_ALLOWED_EMAILS: EMAIL,
+  };
+}
+
+function cookieFrom(response: Response): string {
+  const cookie = response.headers
+    .getSetCookie()
+    .find((value) => value.startsWith("__Host-zudo.session_token="));
+  if (!cookie) throw new Error("Expected a session cookie");
+  return cookie.split(";", 1)[0] ?? "";
+}
+
+async function createSession(authEnv: AuthRuntimeEnv) {
+  const response = await createAuth(authEnv, { enableInvitedEmailSignUp: true }).handler(
+    new Request(`${BASE_URL}/api/auth/sign-up/email`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: BASE_URL },
+      body: JSON.stringify({
+        name: "Session User",
+        email: EMAIL,
+        password: "correct horse battery staple",
+      }),
+    }),
+  );
+  expect(response.status).toBe(200);
+  return cookieFrom(response);
+}
+
+beforeEach(async () => {
+  await reset();
+  await applyControlMigrations(env.DB, inject("controlMigrations"));
+});
+
+describe("session authentication", () => {
+  it("returns the stable no-store 401 when no Better Auth session exists", async () => {
+    const probe = new Hono<SessionAuthEnv>();
+    probe.use("*", sessionAuthMiddleware);
+    probe.get("/", (context) => context.json(context.get(SESSION_AUTH_CONTEXT_KEY)));
+
+    const response = await probe.fetch(new Request(BASE_URL), runtimeEnv());
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual({
+      error: "session_authentication_required",
+    });
+  });
+
+  it("exposes only the opaque user ID from a valid session", async () => {
+    const authEnv = runtimeEnv();
+    const cookie = await createSession(authEnv);
+    const user = await env.DB.prepare("SELECT id FROM user WHERE email = ?")
+      .bind(EMAIL)
+      .first<{ id: string }>();
+    const probe = new Hono<SessionAuthEnv>();
+    probe.use("*", sessionAuthMiddleware);
+    probe.get("/", (context) => context.json(context.get(SESSION_AUTH_CONTEXT_KEY)));
+
+    const response = await probe.fetch(new Request(BASE_URL, { headers: { cookie } }), authEnv);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ userId: user?.id });
+  });
+});

--- a/workers/control/src/auth/session-auth.ts
+++ b/workers/control/src/auth/session-auth.ts
@@ -1,0 +1,44 @@
+import type { MiddlewareHandler } from "hono";
+import { createMiddleware } from "hono/factory";
+
+import { createAuth, type AuthRuntimeEnv } from "./better-auth.js";
+
+export const SESSION_AUTH_CONTEXT_KEY = "sessionAuth" as const;
+
+/** The owner identity exposed by the browser-session boundary. */
+export interface SessionAuthContext {
+  readonly userId: string;
+}
+
+export interface SessionAuthVariables {
+  readonly [SESSION_AUTH_CONTEXT_KEY]: SessionAuthContext;
+}
+
+export interface SessionAuthEnv {
+  readonly Bindings: AuthRuntimeEnv;
+  readonly Variables: SessionAuthVariables;
+}
+
+/** Resolve the browser cookie boundary without attaching framework context. */
+export async function authenticateSession(
+  request: Request,
+  env: AuthRuntimeEnv,
+): Promise<SessionAuthContext | null> {
+  const session = await createAuth(env).api.getSession({ headers: request.headers });
+  return session === null ? null : { userId: session.user.id };
+}
+
+/** Resolve a Better Auth session and expose only the opaque owner ID. */
+export const sessionAuthMiddleware: MiddlewareHandler<SessionAuthEnv> = createMiddleware(
+  async (context, next) => {
+    const session = await authenticateSession(context.req.raw, context.env);
+    if (session === null) {
+      return context.json({ error: "session_authentication_required" }, 401, {
+        "Cache-Control": "no-store",
+      });
+    }
+
+    context.set(SESSION_AUTH_CONTEXT_KEY, session);
+    await next();
+  },
+);

--- a/workers/control/src/desktop/router.ts
+++ b/workers/control/src/desktop/router.ts
@@ -1,0 +1,9 @@
+import { Hono } from "hono";
+
+/**
+ * Wave-4 desktop mount point. Cookie middleware is deliberately applied only
+ * to `/desktop/authorize` by the parent app; `/desktop/token` stays cookie-free.
+ */
+export const desktopRouter = new Hono<{ Bindings: ControlEnv }>().all("*", (context) =>
+  context.json({ error: "route_not_implemented" }, 404, { "Cache-Control": "no-store" }),
+);

--- a/workers/control/src/machines/router.ts
+++ b/workers/control/src/machines/router.ts
@@ -1,0 +1,6 @@
+import { Hono } from "hono";
+
+/** Wave-4 mount point; unmatched machine-management routes are stable. */
+export const machinesRouter = new Hono<{ Bindings: ControlEnv }>().all("*", (context) =>
+  context.json({ error: "route_not_implemented" }, 404, { "Cache-Control": "no-store" }),
+);

--- a/workers/control/src/projects/projects.test.ts
+++ b/workers/control/src/projects/projects.test.ts
@@ -2,7 +2,15 @@ import { env } from "cloudflare:workers";
 import { reset } from "cloudflare:test";
 import { beforeEach, describe, expect, inject, it } from "vitest";
 
-import { app } from "../app.js";
+import {
+  MACHINE_TOKEN_PREFIX,
+  MACHINE_TOKEN_VERSION,
+  generateMachineToken,
+  hashMachineToken,
+} from "@zudo-ez-host/core";
+
+import { app, createControlApp } from "../app.js";
+import { createAuth, type AuthRuntimeEnv } from "../auth/better-auth.js";
 import { createControlDatabase } from "../db/database.js";
 import { getOwnedProject } from "../db/queries.js";
 import { seedMachine, seedUser } from "../db/seeds.js";
@@ -17,6 +25,7 @@ import { resolveProjectByLabel } from "./resolution.js";
 
 const NOW = 1_700_000_000_000;
 const YEAR_MS = 365 * 24 * 60 * 60 * 1_000;
+const BASE_URL = "https://control.test";
 
 beforeEach(async () => {
   await reset();
@@ -27,6 +36,62 @@ async function seedOwner(id = "usr_test", canonicalHandle = "owner"): Promise<Pr
   const database = createControlDatabase(env.DB);
   await seedUser(database, { id, canonicalHandle, createdAt: NOW });
   return { userId: id };
+}
+
+async function seedMachineCredential(userId: string, canonicalHandle: string) {
+  const database = createControlDatabase(env.DB);
+  await seedUser(database, { id: userId, canonicalHandle, createdAt: NOW });
+  const token = generateMachineToken();
+  await seedMachine(database, {
+    id: `mch_${userId}`,
+    userId,
+    name: `${canonicalHandle} Mac`,
+    credentialHashSha256: await hashMachineToken(token),
+    credentialPrefix: MACHINE_TOKEN_PREFIX,
+    credentialVersion: MACHINE_TOKEN_VERSION,
+    createdAt: Date.now(),
+    expiresAt: Date.now() + YEAR_MS,
+  });
+  return token;
+}
+
+function sessionRuntimeEnv(email: string): ControlEnv & AuthRuntimeEnv {
+  return {
+    DB: env.DB,
+    ARTIFACTS: env.ARTIFACTS,
+    PUBLICATION_RESOLVER: env.PUBLICATION_RESOLVER,
+    BETTER_AUTH_SECRET: `${crypto.randomUUID()}${crypto.randomUUID()}`,
+    BETTER_AUTH_BASE_URL: BASE_URL,
+    BETTER_AUTH_TRUSTED_ORIGINS: BASE_URL,
+    SIGNUP_ALLOWED_EMAILS: email,
+  };
+}
+
+async function createBrowserSession(authEnv: AuthRuntimeEnv, email: string, handle: string) {
+  const response = await createAuth(authEnv, { enableInvitedEmailSignUp: true }).handler(
+    new Request(`${BASE_URL}/api/auth/sign-up/email`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: BASE_URL },
+      body: JSON.stringify({
+        name: handle,
+        email,
+        password: "correct horse battery staple",
+      }),
+    }),
+  );
+  expect(response.status).toBe(200);
+  const cookieHeader = response.headers
+    .getSetCookie()
+    .find((value) => value.startsWith("__Host-zudo.session_token="));
+  if (!cookieHeader) throw new Error("Expected browser session cookie");
+  const user = await env.DB.prepare("SELECT id FROM user WHERE email = ?")
+    .bind(email)
+    .first<{ id: string }>();
+  if (!user) throw new Error("Expected browser session user");
+  await env.DB.prepare("UPDATE user SET canonical_handle = ? WHERE id = ?")
+    .bind(handle, user.id)
+    .run();
+  return { cookie: cookieHeader.split(";", 1)[0] ?? "", userId: user.id };
 }
 
 async function publishProject(projectId: string, ownerId: string, machineId: string) {
@@ -246,15 +311,105 @@ describe("project label resolution", () => {
 });
 
 describe("project registration route", () => {
-  it("requires the machine-authenticated owner context", async () => {
+  it("requires an exact Origin before attempting browser-session authentication", async () => {
     const response = await app.request(
-      new Request("https://control.test/projects", {
+      new Request("https://control.test/api/projects", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ slug: "site" }),
       }),
       {},
       env,
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_origin",
+    });
+  });
+
+  it("allows a machine credential to register and read only its owner's project", async () => {
+    const tokenA = await seedMachineCredential("usr_machine_a", "machinea");
+    const tokenB = await seedMachineCredential("usr_machine_b", "machineb");
+    const response = await app.request(
+      `${BASE_URL}/api/projects`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${tokenA}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ slug: "site", userId: "usr_machine_b" }),
+      },
+      env,
+    );
+
+    expect(response.status).toBe(201);
+    const body = await response.json<{ project: { id: string; userId: string } }>();
+    expect(body.project.userId).toBe("usr_machine_a");
+
+    const ownRead = await app.request(
+      `${BASE_URL}/api/projects/${body.project.id}`,
+      {
+        headers: { authorization: `Bearer ${tokenA}` },
+      },
+      env,
+    );
+    expect(ownRead.status).toBe(200);
+
+    const otherRead = await app.request(
+      `${BASE_URL}/api/projects/${body.project.id}`,
+      {
+        headers: { authorization: `Bearer ${tokenB}` },
+      },
+      env,
+    );
+    expect(otherRead.status).toBe(404);
+  });
+
+  it("allows a browser session to register for itself but not read another owner's data", async () => {
+    const authEnv = sessionRuntimeEnv("browser@example.test");
+    const browser = await createBrowserSession(authEnv, "browser@example.test", "browser");
+    const other = await seedOwner("usr_other_browser", "otherbrowser");
+    const otherProject = await registerProject(env.DB, other, { slug: "private" }, { now: NOW });
+    const response = await createControlApp().request(
+      `${BASE_URL}/api/projects`,
+      {
+        method: "POST",
+        headers: {
+          cookie: browser.cookie,
+          origin: BASE_URL,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ slug: "browser-site", userId: other.userId }),
+      },
+      authEnv,
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      project: { userId: browser.userId },
+    });
+
+    const otherRead = await createControlApp().request(
+      `${BASE_URL}/api/projects/${otherProject.project.id}`,
+      { headers: { cookie: browser.cookie } },
+      authEnv,
+    );
+    expect(otherRead.status).toBe(404);
+  });
+
+  it("does not let a browser session cross the machine-only publish boundary", async () => {
+    const authEnv = sessionRuntimeEnv("publisher@example.test");
+    const browser = await createBrowserSession(authEnv, "publisher@example.test", "publisher");
+    const response = await createControlApp().request(
+      `${BASE_URL}/api/projects/prj_browser/publish/commit`,
+      {
+        method: "POST",
+        headers: { cookie: browser.cookie, origin: BASE_URL },
+        body: JSON.stringify({ attemptId: "att_browser" }),
+      },
+      authEnv,
     );
 
     expect(response.status).toBe(401);

--- a/workers/control/src/projects/router.ts
+++ b/workers/control/src/projects/router.ts
@@ -1,21 +1,32 @@
+import type { MiddlewareHandler } from "hono";
 import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
 
-import { MACHINE_AUTH_CONTEXT_KEY, type MachineAuthContext } from "../auth/index.js";
+import {
+  authenticateMachineRequest,
+  authenticateSession,
+  exactControlCorsMiddleware,
+  hasExactTrustedOrigin,
+  type MachineAuthError,
+} from "../auth/index.js";
+import { createControlDatabase } from "../db/database.js";
+import { getOwnedProject } from "../db/queries.js";
 import { readBoundedJsonRequest, RequestBodyError } from "../http/request-body.js";
 import {
   ProjectRegistrationError,
   registerProject,
+  type ProjectOwnerContext,
   type ProjectRegistrationInput,
 } from "./registration.js";
 
-export const AUTHENTICATED_OWNER_CONTEXT = MACHINE_AUTH_CONTEXT_KEY;
+export const PROJECT_AUTH_CONTEXT_KEY = "projectAuth" as const;
+export const AUTHENTICATED_OWNER_CONTEXT = PROJECT_AUTH_CONTEXT_KEY;
 export const MAX_PROJECT_REGISTRATION_REQUEST_BYTES = 64 * 1024;
 
 const NO_STORE_HEADERS = { "Cache-Control": "no-store" } as const;
 
 export interface ProjectRouteVariables {
-  /** Set by machine-auth middleware before this router is reached. */
-  readonly [MACHINE_AUTH_CONTEXT_KEY]?: MachineAuthContext;
+  readonly [PROJECT_AUTH_CONTEXT_KEY]: ProjectOwnerContext;
 }
 
 type ProjectRouteEnv = {
@@ -28,9 +39,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function parseRegistrationInput(value: unknown): ProjectRegistrationInput | null {
-  if (!isRecord(value) || !("slug" in value)) {
-    return null;
-  }
+  if (!isRecord(value) || !("slug" in value)) return null;
   return {
     slug: value.slug,
     displayName: value.displayName,
@@ -38,11 +47,48 @@ function parseRegistrationInput(value: unknown): ProjectRegistrationInput | null
   };
 }
 
-export const projectsRouter = new Hono<ProjectRouteEnv>().post("/", async (context) => {
-  const owner = context.get(MACHINE_AUTH_CONTEXT_KEY);
-  if (owner === undefined || owner === null) {
-    return context.json({ error: "machine_auth_required" }, 401, NO_STORE_HEADERS);
-  }
+function machineUnauthorized(
+  context: Parameters<MiddlewareHandler<ProjectRouteEnv>>[0],
+  error: MachineAuthError,
+) {
+  return context.json(error, 401, {
+    "Cache-Control": "no-store",
+    "WWW-Authenticate": "Bearer",
+  });
+}
+
+/** Select exactly one authority: an explicit bearer credential, otherwise a session. */
+const projectAuthMiddleware: MiddlewareHandler<ProjectRouteEnv> = createMiddleware(
+  async (context, next) => {
+    if (context.req.header("authorization") !== undefined) {
+      const result = await authenticateMachineRequest(context.req.raw, context.env.DB);
+      if (!result.ok) return machineUnauthorized(context, result.error);
+      context.set(PROJECT_AUTH_CONTEXT_KEY, { userId: result.value.userId });
+      await next();
+      return;
+    }
+
+    if (
+      context.req.method !== "GET" &&
+      context.req.method !== "HEAD" &&
+      !hasExactTrustedOrigin(context.req.raw, context.env.BETTER_AUTH_TRUSTED_ORIGINS)
+    ) {
+      return context.json({ error: "invalid_origin" }, 403, NO_STORE_HEADERS);
+    }
+
+    const session = await authenticateSession(context.req.raw, context.env);
+    if (session === null) {
+      return context.json({ error: "session_authentication_required" }, 401, NO_STORE_HEADERS);
+    }
+    context.set(PROJECT_AUTH_CONTEXT_KEY, session);
+    await next();
+  },
+);
+
+const router = new Hono<ProjectRouteEnv>();
+
+router.post("/", exactControlCorsMiddleware, projectAuthMiddleware, async (context) => {
+  const owner = context.get(PROJECT_AUTH_CONTEXT_KEY);
 
   let body: unknown;
   try {
@@ -87,3 +133,18 @@ export const projectsRouter = new Hono<ProjectRouteEnv>().post("/", async (conte
     return context.json({ error: "project_registration_failed" }, 500, NO_STORE_HEADERS);
   }
 });
+
+router.get("/:projectId", exactControlCorsMiddleware, projectAuthMiddleware, async (context) => {
+  const owner = context.get(PROJECT_AUTH_CONTEXT_KEY);
+  const project = await getOwnedProject(
+    createControlDatabase(context.env.DB),
+    owner.userId,
+    context.req.param("projectId"),
+  );
+  if (project === undefined) {
+    return context.json({ error: "project_not_found" }, 404, NO_STORE_HEADERS);
+  }
+  return context.json({ project }, 200, NO_STORE_HEADERS);
+});
+
+export const projectsRouter = router;

--- a/workers/control/src/publication/commit/commit.test.ts
+++ b/workers/control/src/publication/commit/commit.test.ts
@@ -285,7 +285,6 @@ describe("publication commit", () => {
         context.set(MACHINE_AUTH_CONTEXT_KEY, {
           userId: owner.user.id,
           machineId: owner.machines[0]!.id,
-          canonicalHandle: owner.user.canonicalHandle,
         });
         await next();
       }),

--- a/workers/control/src/publication/contracts/contracts.test.ts
+++ b/workers/control/src/publication/contracts/contracts.test.ts
@@ -608,7 +608,6 @@ describe("authenticated client route surface", () => {
       createMiddleware<MachineAuthEnv>(async (context, next) => {
         context.set(MACHINE_AUTH_CONTEXT_KEY, {
           userId: owner.user.id,
-          canonicalHandle: owner.user.canonicalHandle,
           machineId: owner.machine.id,
         });
         await next();

--- a/workers/control/src/publication/prepare/prepare.test.ts
+++ b/workers/control/src/publication/prepare/prepare.test.ts
@@ -190,7 +190,6 @@ describe("publication prepare", () => {
         context.set(MACHINE_AUTH_CONTEXT_KEY, {
           userId: owner.user.id,
           machineId: owner.machine.id,
-          canonicalHandle: owner.user.canonicalHandle,
         });
         await next();
       }),


### PR DESCRIPTION
Parent: #67

Implements #70.

## Summary

- add explicit session authentication and layered Origin/CSRF enforcement
- separate session-only and machine-bearer boundaries for project operations
- mount the identity, project, publication, and desktop route groups consistently
- fail closed when machine credentials and project ownership disagree

## Test plan

- control Worker session, origin, machine-auth, and router-boundary suites
- full repository gate on the integrated base: `pnpm verify` (8/8 steps, 288 tests)
- worker review: no unresolved findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-ez-host/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790455040&installation_model_id=20910&pr_number=78&repository=zudolab%2Fzudo-ez-host&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-ez-host%2Fpull%2F78&signature=25579f27aeba0099a5a14fec4444254671910cb17e88382a7e34073cad399cd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->