### PR TITLE
Add Better Auth database schema

### DIFF
--- a/workers/control/migrations/0000_exotic_speedball.sql
+++ b/workers/control/migrations/0000_exotic_speedball.sql
@@ -1,3 +1,23 @@
+CREATE TABLE `account` (
+	`id` text PRIMARY KEY NOT NULL,
+	`issuer` text NOT NULL,
+	`account_id` text NOT NULL,
+	`provider_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`access_token` text,
+	`refresh_token` text,
+	`id_token` text,
+	`access_token_expires_at` integer,
+	`refresh_token_expires_at` integer,
+	`scope` text,
+	`password` text,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `account_issuer_accountId_uidx` ON `account` (`issuer`,`account_id`);--> statement-breakpoint
+CREATE INDEX `account_userId_idx` ON `account` (`user_id`);--> statement-breakpoint
 CREATE TABLE `hostname_allocations` (
 	`label` text PRIMARY KEY NOT NULL,
 	`user_id` text NOT NULL,
@@ -149,22 +169,52 @@ CREATE UNIQUE INDEX `publications_attempt_id_unique` ON `publications` (`attempt
 CREATE UNIQUE INDEX `publications_id_project_id_unique` ON `publications` (`id`,`project_id`);--> statement-breakpoint
 CREATE UNIQUE INDEX `publications_project_generation_unique` ON `publications` (`project_id`,`generation`);--> statement-breakpoint
 CREATE INDEX `publications_project_published_at_idx` ON `publications` (`project_id`,`published_at`);--> statement-breakpoint
+CREATE TABLE `session` (
+	`id` text PRIMARY KEY NOT NULL,
+	`expires_at` integer NOT NULL,
+	`token` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer NOT NULL,
+	`ip_address` text,
+	`user_agent` text,
+	`user_id` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `session_token_unique` ON `session` (`token`);--> statement-breakpoint
+CREATE INDEX `session_userId_idx` ON `session` (`user_id`);--> statement-breakpoint
 CREATE TABLE `user` (
 	`id` text PRIMARY KEY NOT NULL,
-	`canonical_handle` text NOT NULL,
+	`canonical_handle` text,
+	`name` text NOT NULL,
+	`email` text NOT NULL,
+	`email_verified` integer DEFAULT false NOT NULL,
+	`image` text,
 	`active_logical_bytes` integer DEFAULT 0 NOT NULL,
 	`reserved_active_delta_bytes` integer DEFAULT 0 NOT NULL,
 	`retained_staged_physical_bytes` integer DEFAULT 0 NOT NULL,
 	`reserved_physical_upload_bytes` integer DEFAULT 0 NOT NULL,
 	`created_at` integer NOT NULL,
-	CONSTRAINT "user_canonical_handle_length" CHECK(length("user"."canonical_handle") between 3 and 20),
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	CONSTRAINT "user_canonical_handle_length" CHECK("user"."canonical_handle" is null or length("user"."canonical_handle") between 3 and 20),
 	CONSTRAINT "user_active_logical_bytes_non_negative" CHECK("user"."active_logical_bytes" >= 0),
 	CONSTRAINT "user_reserved_active_delta_bytes_non_negative" CHECK("user"."reserved_active_delta_bytes" >= 0),
 	CONSTRAINT "user_retained_staged_physical_bytes_non_negative" CHECK("user"."retained_staged_physical_bytes" >= 0),
 	CONSTRAINT "user_reserved_physical_upload_bytes_non_negative" CHECK("user"."reserved_physical_upload_bytes" >= 0)
 );
 --> statement-breakpoint
+CREATE UNIQUE INDEX `user_email_unique` ON `user` (`email`);--> statement-breakpoint
 CREATE UNIQUE INDEX `user_canonical_handle_unique` ON `user` (`canonical_handle`);--> statement-breakpoint
+CREATE TABLE `verification` (
+	`id` text PRIMARY KEY NOT NULL,
+	`identifier` text NOT NULL,
+	`value` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `verification_identifier_idx` ON `verification` (`identifier`);--> statement-breakpoint
 CREATE TABLE `verified_objects` (
 	`project_id` text NOT NULL,
 	`content_hash` text NOT NULL,

--- a/workers/control/migrations/meta/0000_snapshot.json
+++ b/workers/control/migrations/meta/0000_snapshot.json
@@ -1,9 +1,139 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "49bb010f-3a5b-4d81-b2b5-2a22343d59ff",
+  "id": "e6f737e3-2495-445b-9c4d-2091fff4c141",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_issuer_accountId_uidx": {
+          "name": "account_issuer_accountId_uidx",
+          "columns": ["issuer", "account_id"],
+          "isUnique": true
+        },
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "hostname_allocations": {
       "name": "hostname_allocations",
       "columns": {
@@ -915,6 +1045,94 @@
         }
       }
     },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "user": {
       "name": "user",
       "columns": {
@@ -929,7 +1147,36 @@
           "name": "canonical_handle",
           "type": "text",
           "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
           "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
           "autoincrement": false
         },
         "active_logical_bytes": {
@@ -970,9 +1217,22 @@
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
         }
       },
       "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        },
         "user_canonical_handle_unique": {
           "name": "user_canonical_handle_unique",
           "columns": ["canonical_handle"],
@@ -985,7 +1245,7 @@
       "checkConstraints": {
         "user_canonical_handle_length": {
           "name": "user_canonical_handle_length",
-          "value": "length(\"user\".\"canonical_handle\") between 3 and 20"
+          "value": "\"user\".\"canonical_handle\" is null or length(\"user\".\"canonical_handle\") between 3 and 20"
         },
         "user_active_logical_bytes_non_negative": {
           "name": "user_active_logical_bytes_non_negative",
@@ -1004,6 +1264,66 @@
           "value": "\"user\".\"reserved_physical_upload_bytes\" >= 0"
         }
       }
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": ["identifier"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
     },
     "verified_objects": {
       "name": "verified_objects",

--- a/workers/control/migrations/meta/0001_snapshot.json
+++ b/workers/control/migrations/meta/0001_snapshot.json
@@ -1,9 +1,139 @@
 {
-  "id": "6ba194b4-3b2d-4df1-882f-46c632bf2439",
-  "prevId": "49bb010f-3a5b-4d81-b2b5-2a22343d59ff",
+  "id": "b651e045-685b-433d-b8f4-792fb6901ee7",
+  "prevId": "e6f737e3-2495-445b-9c4d-2091fff4c141",
   "version": "6",
   "dialect": "sqlite",
   "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_issuer_accountId_uidx": {
+          "name": "account_issuer_accountId_uidx",
+          "columns": ["issuer", "account_id"],
+          "isUnique": true
+        },
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": ["user_id"],
+          "tableTo": "user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "hostname_allocations": {
       "name": "hostname_allocations",
       "columns": {
@@ -915,6 +1045,94 @@
         }
       }
     },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": ["user_id"],
+          "tableTo": "user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "user": {
       "name": "user",
       "columns": {
@@ -929,7 +1147,36 @@
           "name": "canonical_handle",
           "type": "text",
           "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
           "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
           "autoincrement": false
         },
         "active_logical_bytes": {
@@ -970,9 +1217,22 @@
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
         }
       },
       "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        },
         "user_canonical_handle_unique": {
           "name": "user_canonical_handle_unique",
           "columns": ["canonical_handle"],
@@ -985,7 +1245,7 @@
       "checkConstraints": {
         "user_canonical_handle_length": {
           "name": "user_canonical_handle_length",
-          "value": "length(\"user\".\"canonical_handle\") between 3 and 20"
+          "value": "\"user\".\"canonical_handle\" is null or length(\"user\".\"canonical_handle\") between 3 and 20"
         },
         "user_active_logical_bytes_non_negative": {
           "name": "user_active_logical_bytes_non_negative",
@@ -1004,6 +1264,66 @@
           "value": "\"user\".\"reserved_physical_upload_bytes\" >= 0"
         }
       }
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": ["identifier"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
     },
     "verified_objects": {
       "name": "verified_objects",

--- a/workers/control/migrations/meta/_journal.json
+++ b/workers/control/migrations/meta/_journal.json
@@ -5,14 +5,14 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1787824717375,
-      "tag": "0000_curved_solo",
+      "when": 1787855062606,
+      "tag": "0000_exotic_speedball",
       "breakpoints": true
     },
     {
       "idx": 1,
       "version": "6",
-      "when": 1787824718889,
+      "when": 1787855064156,
       "tag": "0001_immutable-invariants",
       "breakpoints": true
     }

--- a/workers/control/src/auth/machine-auth.ts
+++ b/workers/control/src/auth/machine-auth.ts
@@ -165,6 +165,13 @@ export async function authenticateMachineToken(
     return errorResult("unknown_credential");
   }
 
+  // Better Auth creates users before the separate handle-claim flow. Until
+  // publish auth stops carrying handles, an unclaimed account cannot form the
+  // existing publish identity and uses the same non-enumerating failure.
+  if (user.canonicalHandle === null) {
+    return errorResult("unknown_credential");
+  }
+
   return {
     ok: true,
     value: {

--- a/workers/control/src/db/auth-schema.ts
+++ b/workers/control/src/db/auth-schema.ts
@@ -1,0 +1,12 @@
+import { accounts, sessions, users, verifications } from "./schema.js";
+
+/**
+ * Better Auth's Drizzle adapter resolves models with exact schema-object keys.
+ * Keep that contract isolated from the plural exports in the application schema.
+ */
+export const authSchema = {
+  user: users,
+  session: sessions,
+  account: accounts,
+  verification: verifications,
+};

--- a/workers/control/src/db/db.test.ts
+++ b/workers/control/src/db/db.test.ts
@@ -2,6 +2,7 @@ import { env } from "cloudflare:workers";
 import { reset } from "cloudflare:test";
 import { beforeEach, describe, expect, inject, it } from "vitest";
 
+import { authSchema } from "./auth-schema.js";
 import { createControlDatabase } from "./database.js";
 import { executeGuardedBatch } from "./guarded-batch.js";
 import type { GuardedBatchError } from "./guarded-batch.js";
@@ -17,6 +18,7 @@ import {
   getVerifiedObject,
 } from "./queries.js";
 import {
+  accounts,
   hostnameAllocations,
   machines,
   projectHeads,
@@ -25,7 +27,9 @@ import {
   publicationAttempts,
   publicationObjects,
   publications,
+  sessions,
   users,
+  verifications,
   verifiedObjects,
 } from "./schema.js";
 import { seedMachine, seedProject, seedUser } from "./seeds.js";
@@ -75,6 +79,136 @@ describe("control D1 schema", () => {
       "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'publication_attempts'",
     ).first<{ name: string }>();
     expect(table?.name).toBe("publication_attempts");
+  });
+
+  it("exposes the exact Better Auth model keys and applies every auth table and index", async () => {
+    expect(authSchema).toEqual({
+      user: users,
+      session: sessions,
+      account: accounts,
+      verification: verifications,
+    });
+
+    const tables = await env.DB.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('user', 'session', 'account', 'verification') ORDER BY name",
+    ).all<{ name: string }>();
+    expect(tables.results.map(({ name }) => name)).toEqual([
+      "account",
+      "session",
+      "user",
+      "verification",
+    ]);
+
+    const indexes = await env.DB.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND name IN ('session_token_unique', 'session_userId_idx', 'account_issuer_accountId_uidx', 'account_userId_idx', 'user_email_unique', 'verification_identifier_idx') ORDER BY name",
+    ).all<{ name: string }>();
+    expect(indexes.results.map(({ name }) => name)).toEqual([
+      "account_issuer_accountId_uidx",
+      "account_userId_idx",
+      "session_token_unique",
+      "session_userId_idx",
+      "user_email_unique",
+      "verification_identifier_idx",
+    ]);
+  });
+
+  it("round-trips Better Auth rows with Date timestamps and an unclaimed handle", async () => {
+    const database = createControlDatabase(env.DB);
+    const createdAt = new Date(NOW);
+    const updatedAt = new Date(NOW + 1);
+    await database.insert(users).values({
+      id: "usr_auth",
+      canonicalHandle: null,
+      name: "Auth User",
+      email: "auth@example.test",
+      emailVerified: false,
+      createdAt,
+      updatedAt,
+    });
+    await database.insert(sessions).values({
+      id: "ses_auth",
+      expiresAt: new Date(NOW + 60_000),
+      token: "session-token",
+      createdAt,
+      updatedAt,
+      userId: "usr_auth",
+    });
+    await database.insert(accounts).values({
+      id: "acc_auth",
+      issuer: "local:credential",
+      accountId: "usr_auth",
+      providerId: "credential",
+      userId: "usr_auth",
+      password: "password-hash",
+      createdAt,
+      updatedAt,
+    });
+    await database.insert(verifications).values({
+      id: "ver_auth",
+      identifier: "auth@example.test",
+      value: "verification-value",
+      expiresAt: new Date(NOW + 60_000),
+      createdAt,
+      updatedAt,
+    });
+
+    const user = await database.select().from(users).get();
+    const rawUser = await env.DB.prepare("SELECT created_at AS createdAt FROM user WHERE id = ?")
+      .bind("usr_auth")
+      .first<{ createdAt: number }>();
+    expect(user?.canonicalHandle).toBeNull();
+    expect(user?.createdAt).toBeInstanceOf(Date);
+    expect(user?.createdAt.getTime()).toBe(NOW);
+    expect(rawUser?.createdAt).toBe(NOW);
+    expect((await database.select().from(sessions).get())?.expiresAt).toBeInstanceOf(Date);
+    expect((await database.select().from(accounts).get())?.issuer).toBe("local:credential");
+    expect((await database.select().from(verifications).get())?.expiresAt).toBeInstanceOf(Date);
+
+    await expect(
+      database.insert(accounts).values({
+        id: "acc_duplicate_identity",
+        issuer: "local:credential",
+        accountId: "usr_auth",
+        providerId: "other-credential-config",
+        userId: "usr_auth",
+        createdAt,
+        updatedAt,
+      }),
+    ).rejects.toThrow();
+
+    await env.DB.prepare("DELETE FROM user WHERE id = ?").bind("usr_auth").run();
+    expect(await database.select().from(sessions).get()).toBeUndefined();
+    expect(await database.select().from(accounts).get()).toBeUndefined();
+  });
+
+  it("preserves every user accounting CHECK while allowing only null or valid handles", async () => {
+    const { user } = await seedOwnershipGraph();
+    const definition = await env.DB.prepare(
+      "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'user'",
+    ).first<{ sql: string }>();
+    expect(definition?.sql).toContain("user_canonical_handle_length");
+    expect(definition?.sql).toContain("user_active_logical_bytes_non_negative");
+    expect(definition?.sql).toContain("user_reserved_active_delta_bytes_non_negative");
+    expect(definition?.sql).toContain("user_retained_staged_physical_bytes_non_negative");
+    expect(definition?.sql).toContain("user_reserved_physical_upload_bytes_non_negative");
+
+    await expect(
+      env.DB.prepare("UPDATE user SET canonical_handle = 'x' WHERE id = ?").bind(user.id).run(),
+    ).rejects.toThrow("user_canonical_handle_length");
+    await env.DB.prepare("UPDATE user SET canonical_handle = NULL WHERE id = ?")
+      .bind(user.id)
+      .run();
+
+    for (const [column, constraint] of [
+      ["active_logical_bytes", "user_active_logical_bytes_non_negative"],
+      ["reserved_active_delta_bytes", "user_reserved_active_delta_bytes_non_negative"],
+      ["retained_staged_physical_bytes", "user_retained_staged_physical_bytes_non_negative"],
+      ["reserved_physical_upload_bytes", "user_reserved_physical_upload_bytes_non_negative"],
+    ] as const) {
+      await expect(
+        env.DB.prepare(`UPDATE user SET ${column} = -1 WHERE id = ?`).bind(user.id).run(),
+      ).rejects.toThrow(constraint);
+    }
   });
 
   it("round-trips every accounting table with Drizzle types", async () => {

--- a/workers/control/src/db/schema.ts
+++ b/workers/control/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import {
   check,
   foreignKey,
@@ -16,16 +16,32 @@ export const users = sqliteTable(
   "user",
   {
     id: text("id").primaryKey(),
-    canonicalHandle: text("canonical_handle").notNull(),
+    canonicalHandle: text("canonical_handle"),
+    name: text("name").notNull(),
+    email: text("email").notNull().unique(),
+    emailVerified: integer("email_verified", { mode: "boolean" }).notNull().default(false),
+    image: text("image"),
     activeLogicalBytes: integer("active_logical_bytes").notNull().default(0),
     reservedActiveDeltaBytes: integer("reserved_active_delta_bytes").notNull().default(0),
     retainedStagedPhysicalBytes: integer("retained_staged_physical_bytes").notNull().default(0),
     reservedPhysicalUploadBytes: integer("reserved_physical_upload_bytes").notNull().default(0),
-    createdAt: integer("created_at").notNull(),
+    // Better Auth passes and expects a Date for this shared column. Its generated
+    // SQLite schema uses timestamp_ms, so keep one physical created_at column and
+    // convert the accounting fixtures at the seed boundary. Unlike the generator,
+    // this deliberately retains the accounting schema's pre-existing lack of a
+    // SQL default; both Better Auth and accounting writes provide the value.
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
   },
   (table) => [
     uniqueIndex("user_canonical_handle_unique").on(table.canonicalHandle),
-    check("user_canonical_handle_length", sql`length(${table.canonicalHandle}) between 3 and 20`),
+    check(
+      "user_canonical_handle_length",
+      sql`${table.canonicalHandle} is null or length(${table.canonicalHandle}) between 3 and 20`,
+    ),
     check("user_active_logical_bytes_non_negative", nonNegative(table.activeLogicalBytes)),
     check(
       "user_reserved_active_delta_bytes_non_negative",
@@ -41,6 +57,94 @@ export const users = sqliteTable(
     ),
   ],
 );
+
+export const sessions = sqliteTable(
+  "session",
+  {
+    id: text("id").primaryKey(),
+    expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+    token: text("token").notNull().unique(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .$onUpdate(() => new Date())
+      .notNull(),
+    ipAddress: text("ip_address"),
+    userAgent: text("user_agent"),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+  },
+  (table) => [index("session_userId_idx").on(table.userId)],
+);
+
+export const accounts = sqliteTable(
+  "account",
+  {
+    id: text("id").primaryKey(),
+    issuer: text("issuer").notNull(),
+    accountId: text("account_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    accessToken: text("access_token"),
+    refreshToken: text("refresh_token"),
+    idToken: text("id_token"),
+    accessTokenExpiresAt: integer("access_token_expires_at", { mode: "timestamp_ms" }),
+    refreshTokenExpiresAt: integer("refresh_token_expires_at", { mode: "timestamp_ms" }),
+    scope: text("scope"),
+    password: text("password"),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("account_issuer_accountId_uidx").on(table.issuer, table.accountId),
+    index("account_userId_idx").on(table.userId),
+  ],
+);
+
+export const verifications = sqliteTable(
+  "verification",
+  {
+    id: text("id").primaryKey(),
+    identifier: text("identifier").notNull(),
+    value: text("value").notNull(),
+    expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [index("verification_identifier_idx").on(table.identifier)],
+);
+
+export const userRelations = relations(users, ({ many }) => ({
+  sessions: many(sessions),
+  accounts: many(accounts),
+}));
+
+export const sessionRelations = relations(sessions, ({ one }) => ({
+  user: one(users, {
+    fields: [sessions.userId],
+    references: [users.id],
+  }),
+}));
+
+export const accountRelations = relations(accounts, ({ one }) => ({
+  user: one(users, {
+    fields: [accounts.userId],
+    references: [users.id],
+  }),
+}));
 
 export const machines = sqliteTable(
   "machines",
@@ -321,6 +425,8 @@ export const publicationObjects = sqliteTable(
 );
 
 export const schema = {
+  accountRelations,
+  accounts,
   hostnameAllocations,
   machines,
   projectHeads,
@@ -329,11 +435,18 @@ export const schema = {
   publicationAttempts,
   publicationObjects,
   publications,
+  sessionRelations,
+  sessions,
+  userRelations,
   users,
+  verifications,
   verifiedObjects,
 };
 
 export type User = typeof users.$inferSelect;
+export type Session = typeof sessions.$inferSelect;
+export type Account = typeof accounts.$inferSelect;
+export type Verification = typeof verifications.$inferSelect;
 export type Machine = typeof machines.$inferSelect;
 export type Project = typeof projects.$inferSelect;
 export type HostnameAllocation = typeof hostnameAllocations.$inferSelect;

--- a/workers/control/src/db/seeds.ts
+++ b/workers/control/src/db/seeds.ts
@@ -1,12 +1,43 @@
 import type { ControlDatabase } from "./database.js";
-import { machines, projectHeads, projects, users } from "./schema.js";
+import { machines, projectHeads, projects, users, type User } from "./schema.js";
 
-export type UserSeed = typeof users.$inferInsert;
+type UserInsert = typeof users.$inferInsert;
+export type UserSeed = Omit<
+  UserInsert,
+  "createdAt" | "email" | "emailVerified" | "name" | "updatedAt"
+> & {
+  createdAt: Date | number;
+  email?: string;
+  emailVerified?: boolean;
+  name?: string;
+  updatedAt?: Date | number;
+};
 export type MachineSeed = typeof machines.$inferInsert;
 export type ProjectSeed = typeof projects.$inferInsert;
 
-export async function seedUser(database: ControlDatabase, seed: UserSeed) {
-  return database.insert(users).values(seed).returning().get();
+function seedDate(value: Date | number): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+export async function seedUser(
+  database: ControlDatabase,
+  seed: UserSeed & { canonicalHandle: string },
+): Promise<User & { canonicalHandle: string }>;
+export async function seedUser(database: ControlDatabase, seed: UserSeed): Promise<User>;
+export async function seedUser(database: ControlDatabase, seed: UserSeed): Promise<User> {
+  const createdAt = seedDate(seed.createdAt);
+  return database
+    .insert(users)
+    .values({
+      ...seed,
+      createdAt,
+      email: seed.email ?? `${seed.id}@example.invalid`,
+      emailVerified: seed.emailVerified ?? false,
+      name: seed.name ?? seed.canonicalHandle ?? seed.id,
+      updatedAt: seedDate(seed.updatedAt ?? createdAt),
+    })
+    .returning()
+    .get();
 }
 
 export async function seedMachine(database: ControlDatabase, seed: MachineSeed) {


### PR DESCRIPTION
Parent: #67

Implements #68.

## Summary

- add the Better Auth D1 schema alongside the existing publication schema
- keep Drizzle models and generated migrations compatible with the shared database
- add migration, schema, and seed coverage for identity records

## Test plan

- schema and migration regeneration/diff checks
- full repository gate on the integrated base: `pnpm verify` (8/8 steps, 288 tests)
- worker review: no unresolved findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-ez-host/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790455039&installation_model_id=20910&pr_number=82&repository=zudolab%2Fzudo-ez-host&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-ez-host%2Fpull%2F82&signature=c306abdd53e45cd02e71ab57f9cbd67b4bc8b01b2fa8f21802a712064b7177cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->