### PR TITLE
Add account handles and project visibility

### DIFF
--- a/workers/control/src/account/account.test.ts
+++ b/workers/control/src/account/account.test.ts
@@ -1,0 +1,233 @@
+import { env } from "cloudflare:workers";
+import { reset } from "cloudflare:test";
+import { beforeEach, describe, expect, inject, it } from "vitest";
+
+import { app, createControlApp } from "../app.js";
+import { createAuth, type AuthRuntimeEnv } from "../auth/better-auth.js";
+import { createControlDatabase } from "../db/database.js";
+import { seedUser } from "../db/seeds.js";
+import { applyControlMigrations } from "../db/testing.js";
+import { claimHandle, HandleClaimError } from "./handle.js";
+
+const BASE_URL = "https://control.test";
+const PASSWORD = "correct horse battery staple";
+const NOW = 1_700_000_000_000;
+
+function runtimeEnv(allowlist: string): ControlEnv & AuthRuntimeEnv {
+  return {
+    DB: env.DB,
+    ARTIFACTS: env.ARTIFACTS,
+    PUBLICATION_RESOLVER: env.PUBLICATION_RESOLVER,
+    BETTER_AUTH_SECRET: `${crypto.randomUUID()}${crypto.randomUUID()}`,
+    BETTER_AUTH_BASE_URL: BASE_URL,
+    BETTER_AUTH_TRUSTED_ORIGINS: BASE_URL,
+    SIGNUP_ALLOWED_EMAILS: allowlist,
+  };
+}
+
+function sessionCookie(response: Response): string {
+  const cookie = response.headers
+    .getSetCookie()
+    .find((value) => value.startsWith("__Host-zudo.session_token="));
+  if (!cookie) throw new Error("Expected Better Auth to set a session cookie");
+  return cookie.split(";", 1)[0] ?? "";
+}
+
+async function createBrowserSession(authEnv: AuthRuntimeEnv, email: string, name: string) {
+  const response = await createAuth(authEnv, { enableInvitedEmailSignUp: true }).handler(
+    new Request(`${BASE_URL}/api/auth/sign-up/email`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: BASE_URL },
+      body: JSON.stringify({ name, email, password: PASSWORD }),
+    }),
+  );
+  expect(response.status).toBe(200);
+  const user = await env.DB.prepare("SELECT id FROM user WHERE email = ?")
+    .bind(email)
+    .first<{ id: string }>();
+  if (user === null) throw new Error("Expected Better Auth to create a user");
+  return { cookie: sessionCookie(response), userId: user.id };
+}
+
+beforeEach(async () => {
+  await reset();
+  await applyControlMigrations(env.DB, inject("controlMigrations"));
+});
+
+describe("account handle claim", () => {
+  it("validates through the shared hostname grammar and returns stable errors", async () => {
+    const authEnv = runtimeEnv("invalid@example.test");
+    const browser = await createBrowserSession(authEnv, "invalid@example.test", "Invalid User");
+    const request = (handle: unknown) =>
+      createControlApp().request(
+        `${BASE_URL}/api/account/handle`,
+        {
+          method: "POST",
+          headers: {
+            cookie: browser.cookie,
+            origin: BASE_URL,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ handle }),
+        },
+        authEnv,
+      );
+
+    const invalid = await request("bad--handle");
+    expect(invalid.status).toBe(400);
+    await expect(invalid.json()).resolves.toEqual({
+      error: "invalid_handle",
+      reason: "contains_delimiter",
+    });
+
+    const reserved = await request("admin");
+    expect(reserved.status).toBe(400);
+    await expect(reserved.json()).resolves.toEqual({
+      error: "invalid_handle",
+      reason: "reserved_name",
+    });
+  });
+
+  it("claims once, canonicalizes the value, and exposes only the session user", async () => {
+    const authEnv = runtimeEnv("claim@example.test");
+    const browser = await createBrowserSession(authEnv, "claim@example.test", "Claim User");
+
+    const beforeClaim = await createControlApp().request(
+      `${BASE_URL}/api/account/me`,
+      { headers: { cookie: browser.cookie } },
+      authEnv,
+    );
+    expect(beforeClaim.status).toBe(200);
+    await expect(beforeClaim.json()).resolves.toMatchObject({
+      id: browser.userId,
+      handle: null,
+    });
+
+    const claimed = await createControlApp().request(
+      `${BASE_URL}/api/account/handle`,
+      {
+        method: "POST",
+        headers: {
+          cookie: browser.cookie,
+          origin: BASE_URL,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ handle: "Claim-User" }),
+      },
+      authEnv,
+    );
+    expect(claimed.status).toBe(200);
+    await expect(claimed.json()).resolves.toMatchObject({
+      id: browser.userId,
+      email: "claim@example.test",
+      name: "Claim User",
+      handle: "claim-user",
+    });
+
+    const secondClaim = await createControlApp().request(
+      `${BASE_URL}/api/account/handle`,
+      {
+        method: "POST",
+        headers: {
+          cookie: browser.cookie,
+          origin: BASE_URL,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ handle: "another-name" }),
+      },
+      authEnv,
+    );
+    expect(secondClaim.status).toBe(409);
+    await expect(secondClaim.json()).resolves.toEqual({ error: "handle_already_claimed" });
+
+    await expect(
+      env.DB.prepare("SELECT canonical_handle AS handle FROM user WHERE id = ?")
+        .bind(browser.userId)
+        .first(),
+    ).resolves.toEqual({ handle: "claim-user" });
+
+    const withIgnoredId = await createControlApp().request(
+      `${BASE_URL}/api/account/me?userId=another-user`,
+      { headers: { cookie: browser.cookie } },
+      authEnv,
+    );
+    expect(withIgnoredId.status).toBe(200);
+    await expect(withIgnoredId.json()).resolves.toMatchObject({ id: browser.userId });
+  });
+
+  it("uses the unique index as the authority for concurrent claims", async () => {
+    const database = createControlDatabase(env.DB);
+    await seedUser(database, {
+      id: "usr_race_a",
+      canonicalHandle: null,
+      email: "race-a@example.test",
+      name: "Race A",
+      createdAt: NOW,
+    });
+    await seedUser(database, {
+      id: "usr_race_b",
+      canonicalHandle: null,
+      email: "race-b@example.test",
+      name: "Race B",
+      createdAt: NOW,
+    });
+
+    const outcomes = await Promise.allSettled([
+      claimHandle(env.DB, { userId: "usr_race_a" }, "same-handle", { now: NOW }),
+      claimHandle(env.DB, { userId: "usr_race_b" }, "same-handle", { now: NOW }),
+    ]);
+    expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
+    expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
+    const rejected = outcomes.find((outcome) => outcome.status === "rejected");
+    expect(rejected?.status === "rejected" ? rejected.reason : undefined).toBeInstanceOf(
+      HandleClaimError,
+    );
+    expect(
+      rejected?.status === "rejected" ? (rejected.reason as HandleClaimError).code : undefined,
+    ).toBe("handle_taken");
+
+    const rows = await env.DB.prepare(
+      "SELECT id, canonical_handle AS handle FROM user WHERE canonical_handle = ?",
+    )
+      .bind("same-handle")
+      .all<{ id: string; handle: string }>();
+    expect(rows.results).toHaveLength(1);
+    expect(["usr_race_a", "usr_race_b"]).toContain(rows.results[0]?.id);
+  });
+
+  it("reports a handle owned by another account as a conflict", async () => {
+    const database = createControlDatabase(env.DB);
+    await seedUser(database, {
+      id: "usr_taken",
+      canonicalHandle: "taken-handle",
+      email: "taken@example.test",
+      name: "Taken User",
+      createdAt: NOW,
+    });
+    await seedUser(database, {
+      id: "usr_claiming",
+      canonicalHandle: null,
+      email: "claiming@example.test",
+      name: "Claiming User",
+      createdAt: NOW,
+    });
+
+    await expect(
+      claimHandle(env.DB, { userId: "usr_claiming" }, "TAKEN-HANDLE", { now: NOW }),
+    ).rejects.toMatchObject({ code: "handle_taken", status: 409 });
+    await expect(
+      env.DB.prepare("SELECT canonical_handle AS handle FROM user WHERE id = ?")
+        .bind("usr_claiming")
+        .first(),
+    ).resolves.toEqual({ handle: null });
+  });
+
+  it("requires a session for the own-profile routes", async () => {
+    const authEnv = runtimeEnv("anonymous@example.test");
+    const response = await app.request(`${BASE_URL}/api/account/me`, {}, authEnv);
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: "session_authentication_required",
+    });
+  });
+});

--- a/workers/control/src/account/handle.ts
+++ b/workers/control/src/account/handle.ts
@@ -1,0 +1,145 @@
+import { validateHandle, type HostnameValidationReason } from "@zudo-ez-host/core";
+
+import { getAccountProfile, type AccountProfile } from "./queries.js";
+
+export interface AccountOwnerContext {
+  readonly userId: string;
+}
+
+export interface HandleClaimOptions {
+  /** Injectable clock for deterministic tests; production defaults to Date.now. */
+  readonly now?: number;
+}
+
+export type HandleClaimErrorCode =
+  | "invalid_owner_context"
+  | "owner_not_found"
+  | "invalid_handle"
+  | "handle_taken"
+  | "handle_already_claimed";
+
+const STATUS_BY_CODE: Readonly<Record<HandleClaimErrorCode, number>> = {
+  invalid_owner_context: 401,
+  owner_not_found: 401,
+  invalid_handle: 400,
+  handle_taken: 409,
+  handle_already_claimed: 409,
+};
+
+export class HandleClaimError extends Error {
+  readonly code: HandleClaimErrorCode;
+  readonly status: number;
+  readonly reason?: HostnameValidationReason;
+
+  constructor(code: HandleClaimErrorCode, message: string, reason?: HostnameValidationReason) {
+    super(message);
+    this.name = "HandleClaimError";
+    this.code = code;
+    this.status = STATUS_BY_CODE[code];
+    if (reason !== undefined) this.reason = reason;
+  }
+}
+
+function ownerIdFromContext(owner: AccountOwnerContext | string | null | undefined): string {
+  if (typeof owner === "string" && owner.length > 0) return owner;
+  if (
+    owner !== null &&
+    owner !== undefined &&
+    typeof owner !== "string" &&
+    typeof owner.userId === "string" &&
+    owner.userId.length > 0
+  ) {
+    return owner.userId;
+  }
+  throw new HandleClaimError(
+    "invalid_owner_context",
+    "An authenticated owner context with a user ID is required",
+  );
+}
+
+function handleInput(value: unknown): unknown {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return value;
+  return "handle" in value ? value.handle : undefined;
+}
+
+function requireNow(value: number | undefined): number {
+  const now = value ?? Date.now();
+  if (!Number.isSafeInteger(now) || now < 0) {
+    throw new TypeError("Handle claim time must be a non-negative safe integer");
+  }
+  return now;
+}
+
+function isUniqueConstraintViolation(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /\b(unique|constraint)\b/i.test(message);
+}
+
+async function classifyRejectedClaim(database: D1Database, userId: string): Promise<never> {
+  const owner = await getAccountProfile(database, userId);
+  if (owner === null) {
+    throw new HandleClaimError("owner_not_found", "Authenticated owner was not found");
+  }
+  if (owner.handle !== null) {
+    throw new HandleClaimError(
+      "handle_already_claimed",
+      "A canonical handle can only be claimed once",
+    );
+  }
+
+  // The conditional UPDATE is the authority. A zero-change result with an
+  // unclaimed owner means the requested value lost the unique-index race.
+  throw new HandleClaimError("handle_taken", "The requested handle is already taken");
+}
+
+/**
+ * Atomically claim an owner's canonical handle.
+ *
+ * The `canonical_handle IS NULL` predicate makes claiming permanent, while
+ * `user_canonical_handle_unique` is the database arbiter for cross-user races.
+ * No read is used to decide whether a handle is available before the UPDATE.
+ */
+export async function claimHandle(
+  database: D1Database,
+  owner: AccountOwnerContext | string | null | undefined,
+  input: unknown,
+  options: HandleClaimOptions = {},
+): Promise<AccountProfile> {
+  const userId = ownerIdFromContext(owner);
+  const parsed = validateHandle(handleInput(input));
+  if (!parsed.ok) {
+    throw new HandleClaimError("invalid_handle", "Handle is not valid", parsed.reason);
+  }
+  const now = requireNow(options.now);
+
+  let result: D1Result;
+  try {
+    result = await database
+      .prepare(
+        `UPDATE user
+         SET canonical_handle = ?, updated_at = ?
+         WHERE id = ? AND canonical_handle IS NULL`,
+      )
+      .bind(parsed.value, now, userId)
+      .run();
+  } catch (error) {
+    if (!isUniqueConstraintViolation(error)) throw error;
+    return classifyRejectedClaim(database, userId);
+  }
+
+  if (result.meta.changes !== 1) {
+    return classifyRejectedClaim(database, userId);
+  }
+
+  const profile = await getAccountProfile(database, userId);
+  if (profile === null) {
+    throw new Error("Claimed account disappeared after atomic handle update");
+  }
+  if (profile.handle !== parsed.value) {
+    throw new Error("Claimed account returned an unexpected canonical handle");
+  }
+  return profile;
+}
+
+/** Explicit name for code that wants to emphasize the persisted column. */
+export const claimCanonicalHandle = claimHandle;

--- a/workers/control/src/account/index.ts
+++ b/workers/control/src/account/index.ts
@@ -1,0 +1,3 @@
+export * from "./handle.js";
+export * from "./queries.js";
+export * from "./router.js";

--- a/workers/control/src/account/queries.ts
+++ b/workers/control/src/account/queries.ts
@@ -1,0 +1,25 @@
+/** The fields exposed by the signed-in user's own-profile surface. */
+export interface AccountProfile {
+  readonly id: string;
+  readonly email: string;
+  readonly name: string;
+  readonly handle: string | null;
+}
+
+/** Read one account by its authenticated opaque ID. */
+export async function getAccountProfile(
+  database: D1Database,
+  userId: string,
+): Promise<AccountProfile | null> {
+  return database
+    .prepare(
+      `SELECT id, email, name, canonical_handle AS handle
+       FROM user
+       WHERE id = ?`,
+    )
+    .bind(userId)
+    .first<AccountProfile>();
+}
+
+/** Descriptive alias for callers at the /api/account/me boundary. */
+export const getOwnProfile = getAccountProfile;

--- a/workers/control/src/account/router.ts
+++ b/workers/control/src/account/router.ts
@@ -1,6 +1,89 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 
-/** Wave-4 mount point; unmatched account routes have one stable empty response. */
-export const accountRouter = new Hono<{ Bindings: ControlEnv }>().all("*", (context) =>
-  context.json({ error: "route_not_implemented" }, 404, { "Cache-Control": "no-store" }),
+import { SESSION_AUTH_CONTEXT_KEY, type SessionAuthVariables } from "../auth/session-auth.js";
+import { readBoundedJsonRequest, RequestBodyError } from "../http/request-body.js";
+import { claimHandle, HandleClaimError } from "./handle.js";
+import { getAccountProfile } from "./queries.js";
+
+const NO_STORE_HEADERS = { "Cache-Control": "no-store" } as const;
+export const MAX_HANDLE_CLAIM_REQUEST_BYTES = 4 * 1024;
+
+type AccountRouteEnv = {
+  Bindings: ControlEnv;
+  Variables: SessionAuthVariables;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function handleFromBody(value: unknown): unknown {
+  return isRecord(value) && "handle" in value ? value.handle : undefined;
+}
+
+function hasHandleField(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && "handle" in value;
+}
+
+function handleErrorResponse(context: Context<AccountRouteEnv>, error: HandleClaimError) {
+  return context.json(
+    {
+      error: error.code,
+      ...(error.reason === undefined ? {} : { reason: error.reason }),
+    },
+    error.status as ContentfulStatusCode,
+    NO_STORE_HEADERS,
+  );
+}
+
+/** Session-authenticated own-account routes; unmatched paths stay stable. */
+export const accountRouter = new Hono<AccountRouteEnv>();
+
+accountRouter.get("/me", async (context) => {
+  const owner = context.get(SESSION_AUTH_CONTEXT_KEY);
+  if (owner === undefined || owner === null) {
+    return context.json({ error: "session_authentication_required" }, 401, NO_STORE_HEADERS);
+  }
+  const profile = await getAccountProfile(context.env.DB, owner.userId);
+  if (profile === null) {
+    return context.json({ error: "account_not_found" }, 404, NO_STORE_HEADERS);
+  }
+  return context.json(profile, 200, NO_STORE_HEADERS);
+});
+
+accountRouter.post("/handle", async (context) => {
+  const owner = context.get(SESSION_AUTH_CONTEXT_KEY);
+  if (owner === undefined || owner === null) {
+    return context.json({ error: "session_authentication_required" }, 401, NO_STORE_HEADERS);
+  }
+  let body: unknown;
+  try {
+    body = await readBoundedJsonRequest(context.req.raw, MAX_HANDLE_CLAIM_REQUEST_BYTES);
+  } catch (error) {
+    if (error instanceof RequestBodyError) {
+      return context.json(
+        { error: error.reason === "body_too_large" ? "request_body_too_large" : "invalid_json" },
+        error.status,
+        NO_STORE_HEADERS,
+      );
+    }
+    return context.json({ error: "invalid_json" }, 400, NO_STORE_HEADERS);
+  }
+  if (!hasHandleField(body)) {
+    return context.json({ error: "invalid_request" }, 400, NO_STORE_HEADERS);
+  }
+
+  try {
+    const profile = await claimHandle(context.env.DB, owner, handleFromBody(body));
+    return context.json(profile, 200, NO_STORE_HEADERS);
+  } catch (error) {
+    if (error instanceof HandleClaimError) return handleErrorResponse(context, error);
+    return context.json({ error: "handle_claim_failed" }, 500, NO_STORE_HEADERS);
+  }
+});
+
+accountRouter.all("*", (context) =>
+  context.json({ error: "route_not_implemented" }, 404, NO_STORE_HEADERS),
 );

--- a/workers/control/src/projects/projects.test.ts
+++ b/workers/control/src/projects/projects.test.ts
@@ -21,6 +21,7 @@ import {
   type ProjectOwnerContext,
   type ProjectRegistrationInput,
 } from "./index.js";
+import { listOwnedProjects } from "./queries.js";
 import { resolveProjectByLabel } from "./resolution.js";
 
 const NOW = 1_700_000_000_000;
@@ -32,7 +33,10 @@ beforeEach(async () => {
   await applyControlMigrations(env.DB, inject("controlMigrations"));
 });
 
-async function seedOwner(id = "usr_test", canonicalHandle = "owner"): Promise<ProjectOwnerContext> {
+async function seedOwner(
+  id = "usr_test",
+  canonicalHandle: string | null = "owner",
+): Promise<ProjectOwnerContext> {
   const database = createControlDatabase(env.DB);
   await seedUser(database, { id, canonicalHandle, createdAt: NOW });
   return { userId: id };
@@ -310,6 +314,67 @@ describe("project label resolution", () => {
   });
 });
 
+describe("project visibility", () => {
+  it("lists only the owner projects with current head and publication attribution", async () => {
+    const owner = await seedOwner("usr_visibility", "visibility");
+    const other = await seedOwner("usr_visibility_other", "other");
+    const published = await registerProject(env.DB, owner, { slug: "published" }, { now: NOW });
+    const draft = await registerProject(env.DB, owner, { slug: "draft" }, { now: NOW + 1 });
+    await registerProject(env.DB, other, { slug: "private" }, { now: NOW });
+    const database = createControlDatabase(env.DB);
+    const machine = await seedMachine(database, {
+      id: "mch_visibility",
+      userId: owner.userId,
+      name: "Visibility Mac",
+      credentialHashSha256: "visibility-machine-hash",
+      credentialPrefix: "zeh_machine_v1_",
+      credentialVersion: 1,
+      createdAt: NOW,
+      expiresAt: NOW + YEAR_MS,
+    });
+    await publishProject(published.project.id, owner.userId, machine.id);
+
+    await expect(listOwnedProjects(env.DB, owner.userId)).resolves.toEqual([
+      {
+        id: published.project.id,
+        slug: "published",
+        displayName: "published",
+        description: null,
+        status: "active",
+        createdAt: NOW,
+        updatedAt: NOW,
+        hostname: "published--visibility",
+        generation: 1,
+        machineNameSnapshot: "Test Mac",
+        publishedAt: NOW + 2,
+      },
+      {
+        id: draft.project.id,
+        slug: "draft",
+        displayName: "draft",
+        description: null,
+        status: "active",
+        createdAt: NOW + 1,
+        updatedAt: NOW + 1,
+        hostname: "draft--visibility",
+        generation: 0,
+        machineNameSnapshot: null,
+        publishedAt: null,
+      },
+    ]);
+  });
+
+  it("rejects registration for an account without a claimed handle", async () => {
+    const owner = await seedOwner("usr_unclaimed", null);
+
+    await expect(
+      registerProject(env.DB, owner, { slug: "site" }, { now: NOW }),
+    ).rejects.toMatchObject({
+      code: "owner_handle_unclaimed",
+    });
+  });
+});
+
 describe("project registration route", () => {
   it("requires an exact Origin before attempting browser-session authentication", async () => {
     const response = await app.request(
@@ -397,6 +462,64 @@ describe("project registration route", () => {
       authEnv,
     );
     expect(otherRead.status).toBe(404);
+  });
+
+  it("lists only the browser session owner's projects", async () => {
+    const authEnv = sessionRuntimeEnv("list-browser@example.test");
+    const browser = await createBrowserSession(authEnv, "list-browser@example.test", "listbrowser");
+    const own = await registerProject(
+      env.DB,
+      { userId: browser.userId },
+      { slug: "visible" },
+      { now: NOW },
+    );
+    const other = await seedOwner("usr_list_other", "listother");
+    const otherProject = await registerProject(env.DB, other, { slug: "hidden" }, { now: NOW });
+
+    const response = await createControlApp().request(
+      `${BASE_URL}/api/projects`,
+      { headers: { cookie: browser.cookie } },
+      authEnv,
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json<{
+      projects: Array<{ id: string; hostname: string | null; generation: number }>;
+    }>();
+    expect(body.projects).toEqual([
+      expect.objectContaining({
+        id: own.project.id,
+        hostname: "visible--listbrowser",
+        generation: 0,
+      }),
+    ]);
+    expect(body.projects.some(({ id }) => id === otherProject.project.id)).toBe(false);
+  });
+
+  it("returns a stable conflict when the browser owner has not claimed a handle", async () => {
+    const authEnv = sessionRuntimeEnv("unclaimed-browser@example.test");
+    const browser = await createBrowserSession(
+      authEnv,
+      "unclaimed-browser@example.test",
+      "Unclaimed User",
+    );
+    await env.DB.prepare("UPDATE user SET canonical_handle = NULL WHERE id = ?")
+      .bind(browser.userId)
+      .run();
+    const response = await createControlApp().request(
+      `${BASE_URL}/api/projects`,
+      {
+        method: "POST",
+        headers: {
+          cookie: browser.cookie,
+          origin: BASE_URL,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ slug: "site" }),
+      },
+      authEnv,
+    );
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "owner_handle_unclaimed" });
   });
 
   it("does not let a browser session cross the machine-only publish boundary", async () => {

--- a/workers/control/src/projects/queries.ts
+++ b/workers/control/src/projects/queries.ts
@@ -1,0 +1,80 @@
+export interface OwnedProjectVisibility {
+  readonly id: string;
+  readonly slug: string;
+  readonly displayName: string;
+  readonly description: string | null;
+  readonly status: "active" | "taken_down";
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly hostname: string | null;
+  readonly generation: number;
+  readonly machineNameSnapshot: string | null;
+  readonly publishedAt: number | null;
+}
+
+interface OwnedProjectVisibilityRow {
+  readonly id: string;
+  readonly slug: string;
+  readonly displayName: string;
+  readonly description: string | null;
+  readonly status: "active" | "taken_down";
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly hostname: string | null;
+  readonly generation: number | null;
+  readonly machineNameSnapshot: string | null;
+  readonly publishedAt: number | null;
+}
+
+/**
+ * List only the projects owned by one authenticated opaque user ID.
+ *
+ * The publication join follows `project_heads.publication_id`, so historical
+ * publications cannot be mistaken for the current public head. Left joins
+ * preserve generation-zero projects, whose publication fields are null.
+ */
+export async function listOwnedProjects(
+  database: D1Database,
+  userId: string,
+): Promise<readonly OwnedProjectVisibility[]> {
+  const result = await database
+    .prepare(
+      `SELECT p.id, p.slug, p.display_name AS displayName,
+              p.description, p.status,
+              p.created_at AS createdAt, p.updated_at AS updatedAt,
+              h.label AS hostname,
+              ph.generation AS generation,
+              pub.machine_name_snapshot AS machineNameSnapshot,
+              pub.published_at AS publishedAt
+       FROM projects AS p
+       LEFT JOIN hostname_allocations AS h
+         ON h.project_id = p.id AND h.user_id = p.user_id
+       LEFT JOIN project_heads AS ph
+         ON ph.project_id = p.id
+       LEFT JOIN publications AS pub
+         ON pub.id = ph.publication_id
+        AND pub.project_id = p.id
+        AND pub.generation = ph.generation
+       WHERE p.user_id = ?
+       ORDER BY p.created_at ASC, p.id ASC`,
+    )
+    .bind(userId)
+    .all<OwnedProjectVisibilityRow>();
+
+  return result.results.map((row) => ({
+    id: row.id,
+    slug: row.slug,
+    displayName: row.displayName,
+    description: row.description,
+    status: row.status,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    hostname: row.hostname,
+    generation: row.generation ?? 0,
+    machineNameSnapshot: row.machineNameSnapshot,
+    publishedAt: row.publishedAt,
+  }));
+}
+
+/** Descriptive alias for callers that prefer the project noun first. */
+export const getOwnedProjects = listOwnedProjects;

--- a/workers/control/src/projects/registration.ts
+++ b/workers/control/src/projects/registration.ts
@@ -35,6 +35,7 @@ export interface ProjectRegistrationOptions {
 export type ProjectRegistrationErrorCode =
   | "invalid_owner_context"
   | "owner_not_found"
+  | "owner_handle_unclaimed"
   | "invalid_slug"
   | "invalid_owner_handle"
   | "invalid_display_name"
@@ -67,7 +68,7 @@ export interface ProjectRegistrationResult {
 
 interface UserRow {
   readonly id: string;
-  readonly canonicalHandle: string;
+  readonly canonicalHandle: string | null;
 }
 
 function registrationInvariant(message: string): ProjectRegistrationError {
@@ -233,6 +234,12 @@ export async function registerProject(
 
   // The canonical handle is loaded from the owner row. Any extra handle-like
   // field on the request or context is intentionally ignored.
+  if (user.canonicalHandle === null) {
+    throw new ProjectRegistrationError(
+      "owner_handle_unclaimed",
+      "Authenticated owner must claim a canonical handle before registering a project",
+    );
+  }
   const handle = validateHandle(user.canonicalHandle);
   if (!handle.ok) {
     throw new ProjectRegistrationError(

--- a/workers/control/src/projects/router.ts
+++ b/workers/control/src/projects/router.ts
@@ -12,6 +12,7 @@ import {
 import { createControlDatabase } from "../db/database.js";
 import { getOwnedProject } from "../db/queries.js";
 import { readBoundedJsonRequest, RequestBodyError } from "../http/request-body.js";
+import { listOwnedProjects } from "./queries.js";
 import {
   ProjectRegistrationError,
   registerProject,
@@ -87,6 +88,15 @@ const projectAuthMiddleware: MiddlewareHandler<ProjectRouteEnv> = createMiddlewa
 
 const router = new Hono<ProjectRouteEnv>();
 
+router.get("/", exactControlCorsMiddleware, async (context) => {
+  const session = await authenticateSession(context.req.raw, context.env);
+  if (session === null) {
+    return context.json({ error: "session_authentication_required" }, 401, NO_STORE_HEADERS);
+  }
+  const projects = await listOwnedProjects(context.env.DB, session.userId);
+  return context.json({ projects }, 200, NO_STORE_HEADERS);
+});
+
 router.post("/", exactControlCorsMiddleware, projectAuthMiddleware, async (context) => {
   const owner = context.get(PROJECT_AUTH_CONTEXT_KEY);
 
@@ -126,7 +136,11 @@ router.post("/", exactControlCorsMiddleware, projectAuthMiddleware, async (conte
       }
       return context.json(
         { error: error.code, reason: error.reason },
-        error.code === "owner_not_found" || error.code === "invalid_owner_context" ? 401 : 400,
+        error.code === "owner_not_found" || error.code === "invalid_owner_context"
+          ? 401
+          : error.code === "owner_handle_unclaimed"
+            ? 409
+            : 400,
         NO_STORE_HEADERS,
       );
     }

--- a/workers/public/src/public.test.ts
+++ b/workers/public/src/public.test.ts
@@ -530,7 +530,7 @@ describe("public Worker publication topology", () => {
 
   it("publishes, reuses, rejects stale commits, and serves through the real resolver", async () => {
     const token = await seedE2eMachine();
-    const registration = await controlRequest(token, "/projects", {
+    const registration = await controlRequest(token, "/api/projects", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ slug: "site", displayName: "E2E site" }),

--- a/workers/public/vitest.config.ts
+++ b/workers/public/vitest.config.ts
@@ -36,6 +36,10 @@ export default defineProject({
             modulesRoot: controlAuxiliaryRoot,
             compatibilityDate: "2026-08-27",
             compatibilityFlags: ["nodejs_compat"],
+            bindings: {
+              BETTER_AUTH_BASE_URL: "https://control.test",
+              BETTER_AUTH_TRUSTED_ORIGINS: "https://control.test",
+            },
             d1Databases: { DB: "zudo-ez-host-control-local" },
             r2Buckets: { ARTIFACTS: "zudo-ez-host-artifacts-local" },
           },
@@ -48,6 +52,9 @@ export default defineProject({
     name: "public-worker",
     globalSetup: ["./vitest.global-setup.ts"],
     include: ["src/**/*.test.ts"],
+    // The topology test drives several real control-Worker publication calls.
+    // Keep a workerd-specific budget like the control integration project.
+    testTimeout: 30_000,
     provide: { controlMigrations },
   },
 });


### PR DESCRIPTION
Parent: #67

Implements #71.

## Summary

- add own-profile lookup and one-time canonical handle claiming
- add owner-scoped project registration and project visibility routes
- align the public multi-worker harness with the control API topology

## Test plan

- focused account/project, control Worker, and public topology suites
- full repository gate on the integrated base: `pnpm verify` (8/8 steps, 288 tests)
- worker review: no unresolved findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zudolab/codesmith/zudo-ez-host/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790455040&installation_model_id=20910&pr_number=83&repository=zudolab%2Fzudo-ez-host&return_to=https%3A%2F%2Fgithub.com%2Fzudolab%2Fzudo-ez-host%2Fpull%2F83&signature=b423ec7d4175c7665911cd089711682ea1d97b155f72fa3c54ce971621ae71fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->